### PR TITLE
Bugfix/a spinner rotation

### DIFF
--- a/src/styles/atoms/_atoms.spinner.scss
+++ b/src/styles/atoms/_atoms.spinner.scss
@@ -8,6 +8,7 @@
   animation: $spinner-animation-name $spinner-animation-speed infinite $spinner-animation-timing;
   color: $spinner-color;
   content: '\f1ce';
+  display: inline-block;
   font-size: rem($spinner-size);
 }
 


### PR DESCRIPTION
The spinner was not spinning without the display property set to either `block` or `inline-block`.