### PR TITLE
Fix missing devDependencies when running gulp build

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,13 @@
     "gulp-sass": "^3.1.0",
     "gulp-sass-lint": "^1.3.2",
     "gulp-sourcemaps": "^2.4.1",
+    "gulp-util": "^3.0.8",
     "gulp-watch": "^4.3.11",
     "list-selectors": "^2.0.0",
     "lodash": "^4.17.4",
     "merge-stream": "^1.0.1",
     "run-sequence": "^1.2.2",
-    "sass-vars-to-js": "^0.8.7"
+    "sass-vars-to-js": "^0.8.7",
+    "yargs": "^8.0.1"
   }
 }


### PR DESCRIPTION
Running gulp build results in missing modules:

* yargs
* gulp-util

Fixed by running npm install --save-dev yargs gulp-util