### PR TITLE
prevent nested flyouts from all opening when the highest in order is …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## Unreleased
-
+### Fixed
+- Prevent nested flyouts from all opening when the highest in order is opened.
 
 ## [1.2.1] - 2017-11-28
 ### Fixed

--- a/src/styles/molecules/_molecules.flyout.scss
+++ b/src/styles/molecules/_molecules.flyout.scss
@@ -96,7 +96,7 @@
  * -------------------------------------------------------------------
  */
 
-.m-flyout.is-open .m-flyout__content {
+.m-flyout.is-open > .m-flyout__content {
   opacity: 1;
   transform: translateY(0);
   transition-delay: 0s;


### PR DESCRIPTION
I have a flyout with a datepicker inside it, when I open the flyout the datepicker's flyout opens as well which is inconvenient.