### PR TITLE
Fix voor a-input select

### DIFF
--- a/docs/styles/main.css
+++ b/docs/styles/main.css
@@ -2951,6 +2951,7 @@ textarea:focus {
 .a-input select {
 	min-height: 3rem;
 	padding: 0.75rem 1.5rem;
+	font-size: 15px;
 }
 
 .a-input textarea {


### PR DESCRIPTION
Onderkant van de letters in dropdowns vallen steeds weg.
![image](https://user-images.githubusercontent.com/5755057/51027067-4181a480-1590-11e9-8b48-47b858f85998.png)

https://imgur.com/a/xo1WBPB 
Als ik font-size: 15px; toevoeg lijkt het wel te werken