### PR TITLE
Replace SASS spacer variables by CSS properties in all molecules

### DIFF
--- a/src/styles/molecules/_molecules.accordion.scss
+++ b/src/styles/molecules/_molecules.accordion.scss
@@ -9,7 +9,7 @@ $accordion-header-bg-hover:   $background-color-light !default;
 $accordion-content-bg:        $accordion-header-bg !default;
 $accordion-icon-color:        $brand-primary !default;
 $accordion-icon-size:         $icon-size-sm !default;
-$accordion-header-padding:    $spacer-xs $spacer-lg $spacer-xs $spacer-xs !default;
+$accordion-header-padding:    var(--spacer-xs) var(--spacer-lg) var(--spacer-xs) var(--spacer-xs) !default;
 $accordion-content-padding:   var(--spacer) !default;
 
 

--- a/src/styles/molecules/_molecules.alert.scss
+++ b/src/styles/molecules/_molecules.alert.scss
@@ -37,7 +37,7 @@ $alert-padding:           var(--spacer) !default;
  */
 
 .m-alert__actions {
-  margin-bottom: -$spacer-xs;
+  margin-bottom: calc(var(--spacer-xs) * -1);
 
   @include at($screen-xs) {
     display: flex;

--- a/src/styles/molecules/_molecules.breadcrumb.scss
+++ b/src/styles/molecules/_molecules.breadcrumb.scss
@@ -29,7 +29,7 @@ $breadcrumb-arrow-color:  $grey !default;
       content: '';
       display: inline-block;
       height: rem($icon-size-ti);
-      margin: 0 $spacer-xs;
+      margin: 0 var(--spacer-xs);
       mask: url('data:image/svg+xml;utf8,<svg id=%22arrow-right-1%22 viewBox=%22-1 -1 17 17%22 xml:space=%22preserve%22 xmlns=%22http://www.w3.org/2000/svg%22><style>.bbst0{fill:none;stroke:%23ffffff;stroke-width:6.25%;stroke-linecap:round;stroke-linejoin:round}</style><path class=%22bbst0%22 d=%22M3.6 14.5l7.7-6.8c.1-.1.1-.3 0-.4L3.6.5%22/></svg>') no-repeat center center;
       vertical-align: middle;
       width: rem($icon-size-ti);

--- a/src/styles/molecules/_molecules.button-list.scss
+++ b/src/styles/molecules/_molecules.button-list.scss
@@ -19,7 +19,7 @@
 .m-button-list--horizontal {
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: -$spacer-xs;
+  margin-bottom: calc(var(--spacer-xs) * -1);
 
   li {
     margin-bottom: var(--spacer-xs);

--- a/src/styles/molecules/_molecules.card.scss
+++ b/src/styles/molecules/_molecules.card.scss
@@ -3,7 +3,7 @@
  * -------------------------------------------------------------------
  */
 
-$card-header-padding:    $spacer-xs !default;
+$card-header-padding:    var(--spacer-xs) !default;
 $card-content-padding:   var(--spacer) !default;
 
 

--- a/src/styles/molecules/_molecules.collapsible-list.scss
+++ b/src/styles/molecules/_molecules.collapsible-list.scss
@@ -44,7 +44,7 @@
 
   .ai {
     font-size: .875em;
-    padding: 0 ($spacer-xs / 2) 0 0;
+    padding: 0 calc(var(--spacer-xs) / 2) 0 0;
   }
 }
 

--- a/src/styles/molecules/_molecules.contact.scss
+++ b/src/styles/molecules/_molecules.contact.scss
@@ -9,5 +9,5 @@
 }
 
 .m-contact__info {
-  padding: 0 $spacer-xs;
+  padding: 0 var(--spacer-xs);
 }

--- a/src/styles/molecules/_molecules.datepicker.scss
+++ b/src/styles/molecules/_molecules.datepicker.scss
@@ -32,7 +32,7 @@ $datepicker-unavailable-bg:          $datepicker-bg !default;
 .m-datepicker {
   max-width: calc(var(--spacer) * 14);
   opacity: 0;
-  transform: translateY(-$spacer-lg);
+  transform: translateY(calc(var(--spacer-lg) * -1));
   transition: visibility 0s $animation-duration $animation-easing, opacity $animation-normal, transform $animation-normal;
   visibility: hidden;
 

--- a/src/styles/molecules/_molecules.flyout.scss
+++ b/src/styles/molecules/_molecules.flyout.scss
@@ -34,7 +34,7 @@ $flyout-max-height:       calc(var(--spacer) * 9) !default;
   box-shadow: $box-shadow;
   opacity: 0;
   position: absolute;
-  transform: translateY(-$spacer-lg);
+  transform: translateY(calc(var(--spacer-lg) * -1));
   transition: visibility 0s $animation-duration $animation-easing, opacity $animation-normal, transform $animation-normal;
   visibility: hidden;
   z-index: layer('flyout');
@@ -118,7 +118,7 @@ $flyout-max-height:       calc(var(--spacer) * 9) !default;
 }
 
 .m-flyout__content.has-padding {
-  padding: calc(var(--spacer) / 3 * 2) $spacer;
+  padding: calc(var(--spacer) / 3 * 2) var(--spacer);
 }
 
 

--- a/src/styles/molecules/_molecules.modal.scss
+++ b/src/styles/molecules/_molecules.modal.scss
@@ -49,7 +49,7 @@ $modal-padding:           var(--spacer) !default;
 }
 
 .m-modal__footer {
-  margin-bottom: -$spacer-xs;
+  margin-bottom: calc(var(--spacer-xs) * -1);
 
   @include at($screen-xs) {
     display: flex;

--- a/src/styles/molecules/_molecules.pagination.scss
+++ b/src/styles/molecules/_molecules.pagination.scss
@@ -4,7 +4,7 @@
  */
 
 $pagination-font-size:                $btn-font-size !default;
-$pagination-size:                     $spacer-lg !default;
+$pagination-size:                     var(--spacer-lg) !default;
 
 $pagination-color:                    $btn-primary-color !default;
 $pagination-color-disabled:           $btn-disabled-color !default;
@@ -18,8 +18,8 @@ $pagination-outline-bg-hover:         mix($pagination-outline-color, $white, 15%
 $pagination-outline-border:           $pagination-outline-color !default;
 $pagination-outline-border-hover:     mix($pagination-outline-border, $rich-black, 85%) !default;
 
-$pagination-size-sm:                  $spacer-md !default;
-$pagination-size-lg:                  $spacer-xl !default;
+$pagination-size-sm:                  var(--spacer-md) !default;
+$pagination-size-lg:                  var(--spacer-xl) !default;
 
 
 /**
@@ -70,7 +70,7 @@ $pagination-size-lg:                  $spacer-xl !default;
   }
 
   .m-pagination__label {
-    padding: 0 $spacer;
+    padding: 0 var(--spacer);
     width: auto;
   }
 
@@ -148,7 +148,7 @@ $pagination-size-lg:                  $spacer-xl !default;
     }
 
     .m-pagination__label {
-      padding: 0 $spacer-xs;
+      padding: 0 var(--spacer-xs);
       width: auto;
     }
   }
@@ -163,7 +163,7 @@ $pagination-size-lg:                  $spacer-xl !default;
     }
 
     .m-pagination__label {
-      padding: 0 $spacer-md;
+      padding: 0 var(--spacer-md);
       width: auto;
     }
   }

--- a/src/styles/molecules/_molecules.progress.scss
+++ b/src/styles/molecules/_molecules.progress.scss
@@ -21,7 +21,7 @@ $progress-tooltip-bottom:   $progress-height - $progress-bar-padding + $tooltip-
 
 .m-progress__label {
   display: block;
-  margin-bottom: $spacer-sm / 2;
+  margin-bottom: calc(var(--spacer-sm) / 2);
   text-align: left;
 }
 

--- a/src/styles/molecules/_molecules.step-indicator.scss
+++ b/src/styles/molecules/_molecules.step-indicator.scss
@@ -15,7 +15,7 @@ $step-indicator-color-success:          $white !default;
 $step-indicator-bg-success:             $state-success !default;
 $step-indicator-border-success:         $step-indicator-bg-success !default;
 $step-indicator-label-color-success:    $step-indicator-bg-success !default;
-$step-indicator-square-size:            $spacer-md !default;
+$step-indicator-square-size:            var(--spacer-md) !default;
 
 
 /**
@@ -58,13 +58,13 @@ $step-indicator-square-size:            $spacer-md !default;
       font-size: $font-size-h6;
       font-weight: $bold;
       height: $step-indicator-square-size;
-      margin: 0 auto $spacer;
+      margin: 0 auto var(--spacer);
       padding: calc(var(--spacer) / 3) 0;
       text-align: center;
       width: $step-indicator-square-size;
 
       @include at($screen-sm) {
-        margin: 0 auto $spacer-xs;
+        margin: 0 auto var(--spacer-xs);
       }
     }
 
@@ -74,9 +74,9 @@ $step-indicator-square-size:            $spacer-md !default;
       content: '';
       height: 1px;
       position: absolute;
-      right: calc(50% + #{$step-indicator-square-size / 4 * 3});
-      top: calc(#{$step-indicator-square-size / 2} - .5px);
-      width: calc(100% - #{$step-indicator-square-size * 3 / 2});
+      right: calc(50% + #{$step-indicator-square-size} / 4 * 3);
+      top: calc(#{$step-indicator-square-size} / 2 - .5px);
+      width: calc(100% - #{$step-indicator-square-size} * 3 / 2);
     }
 
     &.is-active {
@@ -104,7 +104,7 @@ $step-indicator-square-size:            $spacer-md !default;
       &:after {
         background-color: $step-indicator-border-success;
         height: 2px;
-        top: calc(#{$step-indicator-square-size / 2} - 1px);
+        top: calc(#{$step-indicator-square-size} / 2 - 1px);
       }
     }
 

--- a/src/styles/molecules/_molecules.tag.scss
+++ b/src/styles/molecules/_molecules.tag.scss
@@ -8,7 +8,7 @@ $tag-bg:                  $background-color-light !default;
 $tag-border:              $border-color-light !default;
 $tag-border-focus:        $input-border-focus !default; // Remove this in a later version
 $tag-placeholder:         $input-placeholder !default;
-$tag-height:              $spacer-md !default;
+$tag-height:              var(--spacer-md) !default;
 
 
 /**
@@ -41,7 +41,7 @@ $tag-height:              $spacer-md !default;
   display: block;
   font-weight: $bold;
   max-width: calc(var(--spacer) * 10);
-  padding: 0 $spacer-xs;
+  padding: 0 var(--spacer-xs);
 }
 
 .m-tag__input {
@@ -54,5 +54,5 @@ $tag-height:              $spacer-md !default;
   border-radius: 0;
   max-width: calc(var(--spacer) * 10);
   min-height: $tag-height;
-  padding: 0 $spacer-xs;
+  padding: 0 var(--spacer-xs);
 }

--- a/src/styles/molecules/_molecules.upload.scss
+++ b/src/styles/molecules/_molecules.upload.scss
@@ -4,7 +4,7 @@
  */
 
 $upload-height:              calc(var(--spacer) * 5) !default;
-$upload-padding:             $spacer-md var(--spacer) !default;
+$upload-padding:             var(--spacer-md) var(--spacer) !default;
 
 $upload-color:               $text-color !default;
 $upload-bg:                  $white !default;
@@ -133,7 +133,7 @@ $upload-file-color-danger:    mix($rich-black, $state-danger, 40%) !default;
     color: $upload-file-color;
     line-height: $line-height-paragraph;
     min-height: var(--spacer-md);
-    padding: calc(var(--spacer) / 3) $spacer-lg calc(var(--spacer) / 3) $spacer-lg;
+    padding: calc(var(--spacer) / 3) var(--spacer-lg) calc(var(--spacer) / 3) var(--spacer-lg);
     position: relative;
 
     &:not(:last-child) {


### PR DESCRIPTION
In alle molecules zijn nu de SASS spacer variables omgevormd naar CSS properties. 🙂 