### PR TITLE
Replace SASS spacer variables by CSS properties in all organisms

### DIFF
--- a/src/styles/organisms/_organisms.article.scss
+++ b/src/styles/organisms/_organisms.article.scss
@@ -6,33 +6,33 @@
 $article-h1-font-family:    $font-family-headings !default;
 $article-h1-font-size:      $font-size-h2 !default;
 $article-h1-font-weight:    normal !default;
-$article-h1-margin:         $spacer-lg 0 var(--spacer) !default;
+$article-h1-margin:         var(--spacer-lg) 0 var(--spacer) !default;
 $article-h2-font-family:    $font-family-headings !default;
 $article-h2-font-size:      $font-size-h3 !default;
 $article-h2-font-weight:    normal !default;
-$article-h2-margin:         $spacer-lg 0 var(--spacer) !default;
+$article-h2-margin:         var(--spacer-lg) 0 var(--spacer) !default;
 $article-h3-font-family:    $font-family-base !default;
 $article-h3-font-size:      $font-size-h5 !default;
 $article-h3-font-weight:    $bold !default;
-$article-h3-margin:         var(--spacer) 0 $spacer-xs !default;
+$article-h3-margin:         var(--spacer) 0 var(--spacer-xs) !default;
 $article-h4-font-family:    $font-family-base !default;
 $article-h4-font-size:      $font-size-h6 !default;
 $article-h4-font-weight:    $bold !default;
-$article-h4-margin:         var(--spacer) 0 $spacer-xs !default;
+$article-h4-margin:         var(--spacer) 0 var(--spacer-xs) !default;
 $article-h5-font-family:    $font-family-base !default;
 $article-h5-font-size:      $font-size-base !default;
 $article-h5-font-weight:    $bold !default;
-$article-h5-margin:         $spacer-xs 0 $spacer-xs / 2 !default;
+$article-h5-margin:         var(--spacer-xs) 0 calc(var(--spacer-xs) / 2) !default;
 $article-h6-font-family:    $font-family-base !default;
 $article-h6-font-size:      $font-size-base !default;
 $article-h6-font-weight:    $bold !default;
-$article-h6-margin:         $spacer-xs 0 $spacer-xs / 2 !default;
+$article-h6-margin:         var(--spacer-xs) 0 calc(var(--spacer-xs) / 2) !default;
 $article-p-font-size:       $font-size-base !default;
-$article-p-margin:          0 0 $spacer-xs / 2 !default;
+$article-p-margin:          0 0 calc(var(--spacer-xs) / 2) !default;
 $article-ul-font-size:      $font-size-base !default;
-$article-ul-margin:         0 0 $spacer-xs / 2 !default;
+$article-ul-margin:         0 0 calc(var(--spacer-xs) / 2) !default;
 $article-ol-font-size:      $font-size-base !default;
-$article-ol-margin:         0 0 $spacer-xs / 2 !default;
+$article-ol-margin:         0 0 calc(var(--spacer-xs) / 2) !default;
 
 
 /**

--- a/src/styles/organisms/_organisms.footer.scss
+++ b/src/styles/organisms/_organisms.footer.scss
@@ -6,7 +6,7 @@
 $footer-bg:               $rich-black !default;
 $footer-color:            $white !default;
 
-$footer-height:           $spacer-lg !default;
+$footer-height:           var(--spacer-lg) !default;
 
 $footer-font-size-sm:     $font-size-sm !default;
 $footer-font-size-lg:     $font-size-sm !default;
@@ -47,7 +47,7 @@ $footer-line-height:      $line-height-paragraph !default;
   color: $footer-color;
   font-size: rem($footer-font-size-sm);
   line-height: $footer-line-height;
-  padding: 0 $spacer-xs;
+  padding: 0 var(--spacer-xs);
 
   @include to($screen-sm) {
     flex: 1 1 auto;
@@ -55,7 +55,7 @@ $footer-line-height:      $line-height-paragraph !default;
 
   @include at($screen-sm) {
     font-size: rem($footer-font-size-lg);
-    padding: 0 $spacer-xl;
+    padding: 0 var(--spacer-xl);
   }
 
   a {

--- a/src/styles/organisms/_organisms.navigation-menu.scss
+++ b/src/styles/organisms/_organisms.navigation-menu.scss
@@ -4,11 +4,11 @@
  */
 
 $navigation-menu-border:          $border-color-light !default;
-$navigation-menu-mobile-height:   $spacer-xl !default;
+$navigation-menu-mobile-height:   var(--spacer-xl) !default;
 $navigation-menu-pane-width:      20rem !default;
 $navigation-menu-undocked-width:  15rem !default;
 $navigation-menu-docked-width:    $header-height !default;
-$navigation-menu-submenu-inset:   $spacer-xs !default;
+$navigation-menu-submenu-inset:   var(--spacer-xs) !default;
 $navigation-menu-submenu-height:  $navigation-menu-undocked-width * 2 !default;
 $navigation-menu-animation-speed: $animation-duration !default;
 
@@ -340,7 +340,7 @@ $navigation-menu-animation-speed: $animation-duration !default;
 
   // First sub-layer of menus will get larger padding
   & .m-nav-list li .o-menu__submenu li > a {
-    padding-left: calc(#{$navigation-menu-docked-width} + #{$navigation-menu-submenu-inset * 2});
+    padding-left: calc(#{$navigation-menu-docked-width} + #{$navigation-menu-submenu-inset} * 2);
   }
 
   @include at($screen-sm) {
@@ -353,7 +353,7 @@ $navigation-menu-animation-speed: $animation-duration !default;
 
   @include at($screen-sm) {
     display: block;
-    padding: 1rem $spacer-xs;
+    padding: 1rem var(--spacer-xs);
     text-align: right;
 
     > a {

--- a/src/styles/organisms/_organisms.slideshow.scss
+++ b/src/styles/organisms/_organisms.slideshow.scss
@@ -91,11 +91,11 @@
   &.o-slideshow__prev--outside {
 
     @include at($screen-md) {
-      left: -$spacer-lg;
+      left: calc(var(--spacer-lg) * -1);
     }
 
     @include at($screen-lg) {
-      left: -$spacer-lg / 3 * 4;
+      left: calc(var(--spacer-lg) / -3 * 4);
     }
   }
 }
@@ -106,11 +106,11 @@
   &.o-slideshow__next--outside {
 
     @include at($screen-md) {
-      right: -$spacer-lg;
+      right: calc(var(--spacer-lg) * -1);
     }
 
     @include at($screen-lg) {
-      right: -$spacer-lg / 3 * 4;
+      right: calc(var(--spacer-lg) / -3 * 4);
     }
   }
 }

--- a/src/styles/organisms/_organisms.tag-list.scss
+++ b/src/styles/organisms/_organisms.tag-list.scss
@@ -7,7 +7,7 @@
   @extend %a-list--reset;
   display: flex;
   flex-wrap: wrap;
-  margin-bottom: -$spacer-xs;
+  margin-bottom: calc(var(--spacer-xs) * -1);
 
   .m-tag {
     margin-bottom: var(--spacer-xs);


### PR DESCRIPTION
In alle organisms zijn nu de SASS spacer variables omgevormd naar CSS properties. 🙂