### PR TITLE
Replace SASS spacer variables by CSS properties in all other stylesheets

### DIFF
--- a/src/styles/aui/_aui.leaflet.scss
+++ b/src/styles/aui/_aui.leaflet.scss
@@ -117,7 +117,7 @@
     }
 
     .o-leaflet__controls--top-left {
-      left: calc(350px + 2 * #{$spacer-xs});
+      left: calc(350px + 2 * var(--spacer-xs));
     }
   }
 }
@@ -130,7 +130,7 @@
 .leaflet-popup-content-wrapper {
   border: 1px solid $grey-lighter !important;
   border-radius: 0 !important;
-  box-shadow: $spacer-xs $spacer-xs 0 rgba($rich-black, .1) !important;
+  box-shadow: var(--spacer-xs) var(--spacer-xs) 0 rgba($rich-black, .1) !important;
   position: relative;
 
   &:after {
@@ -147,7 +147,7 @@
 
 .leaflet-popup-content {
   font-size: $font-size-sm;
-  margin: $spacer-xs !important;
+  margin: var(--spacer-xs) !important;
 }
 
 .leaflet-container {
@@ -155,7 +155,7 @@
 }
 
 .leaflet-popup-close-button {
-  right: $spacer-xs / 2 !important;
-  top: $spacer-xs / 2 !important;
+  right: calc(var(--spacer-xs) / 2) !important;
+  top: calc(var(--spacer-xs) / 2) !important;
   z-index: layer('base');
 }

--- a/src/styles/aui/_aui.search-filter.scss
+++ b/src/styles/aui/_aui.search-filter.scss
@@ -12,7 +12,7 @@
     height: var(--spacer-lg);
     justify-content: center;
     line-height: var(--spacer-lg);
-    margin: 0 $spacer-xs 0 0;
+    margin: 0 var(--spacer-xs) 0 0;
     padding-left: var(--spacer);
 
     > span:not(.ai) {
@@ -62,7 +62,7 @@
 
   &__clear {
     margin: 0;
-    padding: 0 $spacer-sm $spacer-sm;
+    padding: 0 var(--spacer-sm) var(--spacer-sm);
     text-align: center;
   }
 
@@ -82,7 +82,7 @@
 
   &__results-title {
     font-size: $font-size-base;
-    margin: 0 $spacer-xs;
+    margin: 0 var(--spacer-xs);
   }
 
   &__results-item {

--- a/src/styles/aui/_aui.statusbar.scss
+++ b/src/styles/aui/_aui.statusbar.scss
@@ -46,15 +46,15 @@
     padding: var(--spacer-xs);
 
     @include at($screen-sm) {
-      padding: $spacer-xs $spacer-md;
+      padding: var(--spacer-xs) var(--spacer-md);
     }
 
     @include at($screen-md) {
-      padding: $spacer-xs $spacer-lg;
+      padding: var(--spacer-xs) var(--spacer-lg);
     }
 
     @include at($screen-lg) {
-      padding: $spacer-xs $spacer-xx;
+      padding: var(--spacer-xs) var(--spacer-xx);
     }
 
     p {

--- a/src/styles/base/_base.media.scss
+++ b/src/styles/base/_base.media.scss
@@ -3,7 +3,7 @@
  * -------------------------------------------------------------------
  */
 
-$figcaption-padding:      $spacer-xs !default;
+$figcaption-padding:         var(--spacer-xs) !default;
 
 
 /**
@@ -25,6 +25,6 @@ figcaption {
   padding: $figcaption-padding;
 
   @include at($screen-sm) {
-    padding: $figcaption-padding / 3 * 4 $figcaption-padding;
+    padding: calc(#{$figcaption-padding} / 3 * 4) $figcaption-padding;
   }
 }

--- a/src/styles/base/_base.typography.scss
+++ b/src/styles/base/_base.typography.scss
@@ -103,7 +103,7 @@ p {
 blockquote {
   border-left: 1px solid $border-color-light;
   margin: 0;
-  padding: $spacer-xs 0 $spacer-xs $spacer;
+  padding: var(--spacer-xs) 0 var(--spacer-xs) var(--spacer);
 
   p {
     display: inline;

--- a/src/styles/styleguide.scss
+++ b/src/styles/styleguide.scss
@@ -24,7 +24,7 @@
 .d {
   display: flex;
   flex-direction: column;
-  margin: var(--spacer) $spacer-xs * -1;
+  margin: var(--spacer) calc(var(--spacer-xs) * -1);
 
   @include at($screen-sm) {
     flex-direction: row;
@@ -32,7 +32,7 @@
 
   > div {
     flex: 1 1 auto;
-    padding: calc(var(--spacer) / 4) $spacer-xs 0;
+    padding: calc(var(--spacer) / 4) var(--spacer-xs) 0;
 
     @include at($screen-sm) {
       width: 0;
@@ -47,7 +47,7 @@
 }
 
 .u-margin-bottom-top-xxs {
-  margin: $spacer-xs / 2 0;
+  margin: calc(var(--spacer-xs) / 2) 0;
 }
 
 .d-toc {
@@ -86,9 +86,9 @@
 
   small {
     display: inline-block;
-    padding: $spacer-xs / 4 $spacer-xs / 3 $spacer-xs / 3;
+    padding: calc(var(--spacer-xs) / 4) calc(var(--spacer-xs) / 3) calc(var(--spacer-xs) / 3);
     position: relative;
-    transform: translateY(-$spacer-xs);
+    transform: translateY(calc(var(--spacer-xs) * -1));
   }
 
   @include at($screen-xs) {
@@ -105,7 +105,7 @@
   color: $grey-dark;
   display: inline-block;
   font-weight: bold;
-  margin-top: $spacer-xs / 6;
+  margin-top: calc(var(--spacer-xs) / 6);
 }
 
 .d-alert {
@@ -133,11 +133,11 @@
 .d-list {
   display: flex;
   flex-wrap: wrap;
-  margin-left: $spacer-xs * -1;
-  margin-right: $spacer-xs * -1;
+  margin-left: calc(var(--spacer-xs) * -1);
+  margin-right: calc(var(--spacer-xs) * -1);
 
   > li {
-    padding: 0 $spacer-xs;
+    padding: 0 var(--spacer-xs);
     width: 100%;
 
     @include at($screen-sm) {
@@ -148,7 +148,7 @@
   &__colors {
     > li {
       margin-top: calc(var(--spacer-xs) / 2);
-      padding: calc(var(--spacer) / 2) $spacer-xs calc(var(--spacer) / 2) calc(var(--spacer) * 5);
+      padding: calc(var(--spacer) / 2) var(--spacer-xs) calc(var(--spacer) / 2) calc(var(--spacer) * 5);
       position: relative;
 
       &:nth-child(6n+7) {
@@ -297,7 +297,7 @@
 }
 
 .d-avatar {
-  margin-top: $spacer-xs / 4;
+  margin-top: calc(var(--spacer-xs) / 4);
 }
 
 .d-overlay input:checked ~ .m-overlay {
@@ -334,7 +334,7 @@
   padding-top: var(--spacer-lg);
 
   .o-menu {
-    margin-bottom: -$spacer-xx;
+    margin-bottom: calc(var(--spacer-xx) * -1);
   }
 
   @include at($screen-sm) {
@@ -350,7 +350,7 @@
 .d-icons {
   display: grid;
   // IE11 doesn't support grid-gap, so we fall back to margins. See [*GG].
-  // grid-gap: $spacer-xs / 2 $spacer;
+  // grid-gap: calc(var(--spacer-xs) / 2) var(--spacer);
 
   @include at($screen-sm) {
     grid-template-columns: 1fr 1fr;
@@ -362,7 +362,7 @@
 
   &__row {
     display: grid;
-    grid-template-columns: $spacer-lg auto;
+    grid-template-columns: var(--spacer-lg) auto;
     margin-bottom: calc(var(--spacer-xs) / 2); // [*GG]
 
     @include at($screen-sm) {

--- a/src/styles/utilities/_utilities.layout.scss
+++ b/src/styles/utilities/_utilities.layout.scss
@@ -23,7 +23,7 @@
 .u-container {
   margin: 0 auto;
   max-width: $screen-lg;
-  padding: 0 $spacer-xs;
+  padding: 0 var(--spacer-xs);
   width: 100%;
 }
 


### PR DESCRIPTION
In alle andere stylesheets zijn nu de SASS spacer variables omgevormd naar CSS properties. 🙂