### PR TITLE
Rename spacer CSS properties according to t-shirt size chart

### DIFF
--- a/src/styles/atoms/_atoms.badge.scss
+++ b/src/styles/atoms/_atoms.badge.scss
@@ -5,7 +5,7 @@
 
 $badge-font-size:                $font-size-sm !default;
 $badge-font-weight:              $bold !default;
-$badge-height:                   var(--spacer-sm) !default;
+$badge-height:                   var(--spacer-s) !default;
 $badge-line-height:              $badge-height !default;
 $badge-padding:                  0 calc(var(--spacer) / 4) !default;
 

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -257,7 +257,7 @@
 
   &.a-button--small {
     font-size: rem($btn-font-size-sm);
-    min-height: var(--spacer-md);
+    min-height: var(--spacer-l);
     padding: calc(var(--spacer-sm) / 2) var(--spacer);
 
     .ai {
@@ -336,15 +336,15 @@
 
   &.has-icon-left .ai,
   &.has-icon-right .ai {
-    width: var(--spacer-md);
+    width: var(--spacer-l);
   }
 
   &.has-icon-left {
-    padding-left: var(--spacer-md);
+    padding-left: var(--spacer-l);
   }
 
   &.has-icon-right {
-    padding-right: var(--spacer-md);
+    padding-right: var(--spacer-l);
   }
 }
 
@@ -401,10 +401,10 @@
 }
 
 .a-button--small.has-icon {
-  width: var(--spacer-md);
+  width: var(--spacer-l);
 
   .ai {
-    width: var(--spacer-md);
+    width: var(--spacer-l);
   }
 }
 

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -156,7 +156,7 @@
     content: '';
     display: block;
     height: rem(21px);
-    left: var(--spacer-sm);
+    left: var(--spacer-s);
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
@@ -258,7 +258,7 @@
   &.a-button--small {
     font-size: rem($btn-font-size-sm);
     min-height: var(--spacer-l);
-    padding: calc(var(--spacer-sm) / 2) var(--spacer);
+    padding: calc(var(--spacer-s) / 2) var(--spacer);
 
     .ai {
       font-size: rem($btn-icon-size-sm);
@@ -268,7 +268,7 @@
   &.a-button--large {
     font-size: rem($btn-font-size-lg);
     min-height: var(--spacer-xxl);
-    padding: var(--spacer-sm) var(--spacer);
+    padding: var(--spacer-s) var(--spacer);
 
     .ai {
       font-size: rem($btn-icon-size-lg);

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -21,7 +21,7 @@
   font-weight: $btn-font-weight;
   line-height: 1.25;
   margin: 0;
-  min-height: var(--spacer-lg);
+  min-height: var(--spacer-xl);
   padding: $btn-padding;
   text-align: center;
   text-decoration: none;
@@ -295,12 +295,12 @@
       position: absolute;
       top: 50%;
       transform: translateY(-50%);
-      width: var(--spacer-lg);
+      width: var(--spacer-xl);
     }
   }
 
   &.has-icon-left {
-    padding-left: var(--spacer-lg);
+    padding-left: var(--spacer-xl);
 
     .ai {
       left: 0;
@@ -308,7 +308,7 @@
   }
 
   &.has-icon-right {
-    padding-right: var(--spacer-lg);
+    padding-right: var(--spacer-xl);
 
     .ai {
       right: 0;
@@ -380,14 +380,14 @@
     padding: 0;
     position: relative;
     vertical-align: middle;
-    width: var(--spacer-lg);
+    width: var(--spacer-xl);
 
     .ai {
       left: 0;
       position: absolute;
       top: 50%;
       transform: translateY(-50%);
-      width: var(--spacer-lg);
+      width: var(--spacer-xl);
     }
   }
 }

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -267,7 +267,7 @@
 
   &.a-button--large {
     font-size: rem($btn-font-size-lg);
-    min-height: var(--spacer-xl);
+    min-height: var(--spacer-xxl);
     padding: var(--spacer-sm) var(--spacer);
 
     .ai {
@@ -352,15 +352,15 @@
 
   &.has-icon-left .ai,
   &.has-icon-right .ai {
-    width: var(--spacer-xl);
+    width: var(--spacer-xxl);
   }
 
   &.has-icon-left {
-    padding-left: var(--spacer-xl);
+    padding-left: var(--spacer-xxl);
   }
 
   &.has-icon-right {
-    padding-right: var(--spacer-xl);
+    padding-right: var(--spacer-xxl);
   }
 }
 
@@ -409,10 +409,10 @@
 }
 
 .a-button--large.has-icon {
-  width: var(--spacer-xl);
+  width: var(--spacer-xxl);
 
   .ai {
-    width: var(--spacer-xl);
+    width: var(--spacer-xxl);
   }
 }
 

--- a/src/styles/atoms/_atoms.form.scss
+++ b/src/styles/atoms/_atoms.form.scss
@@ -3,7 +3,7 @@
  * -------------------------------------------------------------------
  */
 
-$fieldset-padding:    var(--spacer-lg) 0 !default;
+$fieldset-padding:    var(--spacer-xl) 0 !default;
 $legend-color:        $grey-dark !default;
 $legend-padding:      0 calc(var(--spacer) / 3) 0 0 !default;
 $legend-size:         $font-size-lg !default;

--- a/src/styles/atoms/_atoms.input.scss
+++ b/src/styles/atoms/_atoms.input.scss
@@ -171,12 +171,12 @@ textarea {
 
     &.has-icon-right {
       .a-input__wrapper:before {
-        right: var(--spacer-md);
+        right: var(--spacer-l);
       }
 
       .a-input__wrapper {
         input {
-          padding-right: calc(var(--spacer-xl) + var(--spacer-md));
+          padding-right: calc(var(--spacer-xl) + var(--spacer-l));
         }
       }
     }

--- a/src/styles/atoms/_atoms.input.scss
+++ b/src/styles/atoms/_atoms.input.scss
@@ -33,7 +33,7 @@ textarea {
 
   small {
     display: block;
-    margin: calc(var(--spacer-sm) / 2) 0;
+    margin: calc(var(--spacer-s) / 2) 0;
     text-align: left;
   }
 
@@ -98,13 +98,13 @@ textarea {
 
 .a-input__label {
   display: inline-block;
-  margin-bottom: calc(var(--spacer-sm) / 2);
+  margin-bottom: calc(var(--spacer-s) / 2);
   text-align: left;
 
   + .a-switch,
   + .a-input__checkbox,
   + .a-input__radio {
-    margin-top: calc(var(--spacer-sm) / 2);
+    margin-top: calc(var(--spacer-s) / 2);
   }
 }
 

--- a/src/styles/atoms/_atoms.input.scss
+++ b/src/styles/atoms/_atoms.input.scss
@@ -166,7 +166,7 @@ textarea {
       right: 0;
       top: 50%;
       transform: translateY(-50%);
-      width: var(--spacer-lg);
+      width: var(--spacer-xl);
     }
 
     &.has-icon-right {
@@ -176,13 +176,13 @@ textarea {
 
       .a-input__wrapper {
         input {
-          padding-right: calc(var(--spacer-lg) + var(--spacer-md));
+          padding-right: calc(var(--spacer-xl) + var(--spacer-md));
         }
       }
     }
 
     input {
-      padding-right: var(--spacer-lg);
+      padding-right: var(--spacer-xl);
     }
   }
 
@@ -229,7 +229,7 @@ textarea {
     top: 50%;
     transform: translateY(-50%);
     user-select: none;
-    width: var(--spacer-lg);
+    width: var(--spacer-xl);
 
     &.is-clickable {
       align-items: center;
@@ -248,7 +248,7 @@ textarea {
   &.has-icon-left .a-input__wrapper {
     input,
     select {
-      padding-left: var(--spacer-lg);
+      padding-left: var(--spacer-xl);
     }
 
     > .ai {
@@ -259,7 +259,7 @@ textarea {
   &.has-icon-right .a-input__wrapper {
     input,
     select {
-      padding-right: var(--spacer-lg);
+      padding-right: var(--spacer-xl);
     }
 
     > .ai {

--- a/src/styles/atoms/_atoms.table.scss
+++ b/src/styles/atoms/_atoms.table.scss
@@ -41,7 +41,7 @@ $table-padding:               var(--spacer-xs) !default;
 
   tr {
     border-bottom: 1px solid $table-border;
-    height: var(--spacer-lg);
+    height: var(--spacer-xl);
     transition: background-color $animation-duration $animation-easing;
 
     &.a-table--clickable,

--- a/src/styles/atoms/_atoms.table.scss
+++ b/src/styles/atoms/_atoms.table.scss
@@ -31,7 +31,7 @@ $table-padding:               var(--spacer-xs) !default;
   width: 100%;
 
   caption {
-    margin-bottom: calc(var(--spacer-sm) / 2);
+    margin-bottom: calc(var(--spacer-s) / 2);
     text-align: left;
   }
 

--- a/src/styles/atoms/_atoms.table.scss
+++ b/src/styles/atoms/_atoms.table.scss
@@ -82,7 +82,7 @@ $table-padding:               var(--spacer-xs) !default;
  */
 
 .a-table.a-table--small tr {
-  height: var(--spacer-md);
+  height: var(--spacer-l);
 }
 
 

--- a/src/styles/atoms/_atoms.timepicker.scss
+++ b/src/styles/atoms/_atoms.timepicker.scss
@@ -10,5 +10,5 @@
 }
 
 .a-timepicker__separator {
-  margin: 0 var(--spacer-xs) var(--spacer-sm);
+  margin: 0 var(--spacer-xs) var(--spacer-s);
 }

--- a/src/styles/atoms/_atoms.toggle.scss
+++ b/src/styles/atoms/_atoms.toggle.scss
@@ -63,7 +63,7 @@
 
   &.a-toggle--small {
     .a-toggle__button {
-      height: var(--spacer-md);
+      height: var(--spacer-l);
     }
   }
 

--- a/src/styles/atoms/_atoms.toggle.scss
+++ b/src/styles/atoms/_atoms.toggle.scss
@@ -69,7 +69,7 @@
 
   &.a-toggle--large {
     .a-toggle__button {
-      height: var(--spacer-xl);
+      height: var(--spacer-xxl);
     }
   }
 }

--- a/src/styles/atoms/_atoms.toggle.scss
+++ b/src/styles/atoms/_atoms.toggle.scss
@@ -22,7 +22,7 @@
   border: none;
   display: flex;
   flex-direction: column;
-  height: var(--spacer-lg);
+  height: var(--spacer-xl);
   overflow: hidden;
   padding: 0;
 

--- a/src/styles/aui/_aui.leaflet.scss
+++ b/src/styles/aui/_aui.leaflet.scss
@@ -32,7 +32,7 @@
 
     &.has-content {
       border-right: solid 1px $grey;
-      padding: var(--spacer-sm);
+      padding: var(--spacer-s);
       width: 300px;
     }
   }
@@ -42,23 +42,23 @@
     z-index: layer('top');
 
     &--bottom-left {
-      bottom: var(--spacer-sm);
-      left: var(--spacer-sm);
+      bottom: var(--spacer-s);
+      left: var(--spacer-s);
     }
 
     &--bottom-right {
-      bottom: var(--spacer-sm);
-      right: var(--spacer-sm);
+      bottom: var(--spacer-s);
+      right: var(--spacer-s);
     }
 
     &--top-left {
-      left: var(--spacer-sm);
-      top: var(--spacer-sm);
+      left: var(--spacer-s);
+      top: var(--spacer-s);
     }
 
     &--top-right {
-      right: var(--spacer-sm);
-      top: var(--spacer-sm);
+      right: var(--spacer-s);
+      top: var(--spacer-s);
     }
 
     &--top-left .o-leaflet__control,
@@ -108,10 +108,10 @@
     .o-leaflet__content {
       border: solid 1px $grey;
       box-shadow: .75rem .75rem 0 rgba($rich-black, .1);
-      left: var(--spacer-sm);
+      left: var(--spacer-s);
       max-height: calc(100% - 160px);
       position: absolute;
-      top: var(--spacer-sm);
+      top: var(--spacer-s);
       width: 350px;
       z-index: layer('top');
     }

--- a/src/styles/aui/_aui.range-slider.scss
+++ b/src/styles/aui/_aui.range-slider.scss
@@ -37,7 +37,7 @@
     display: flex;
     font-size: $font-size-sm;
     justify-content: space-between;
-    margin-top: var(--spacer-sm);
+    margin-top: var(--spacer-s);
 
     .m-range-slider__step {
       width: var(--spacer);

--- a/src/styles/aui/_aui.search-filter.scss
+++ b/src/styles/aui/_aui.search-filter.scss
@@ -9,9 +9,9 @@
     border: 1px solid $border-color;
     cursor: pointer;
     display: flex;
-    height: var(--spacer-lg);
+    height: var(--spacer-xl);
     justify-content: center;
-    line-height: var(--spacer-lg);
+    line-height: var(--spacer-xl);
     margin: 0 var(--spacer-xs) 0 0;
     padding-left: var(--spacer);
 
@@ -22,12 +22,12 @@
     > .ai {
       color: $input-icon;
       font-size: 1.25rem;
-      height: var(--spacer-lg);
-      line-height: var(--spacer-lg);
+      height: var(--spacer-xl);
+      line-height: var(--spacer-xl);
       pointer-events: none;
       text-align: center;
       user-select: none;
-      width: var(--spacer-lg);
+      width: var(--spacer-xl);
     }
 
     &.m-search-filter__label--active {

--- a/src/styles/aui/_aui.search-filter.scss
+++ b/src/styles/aui/_aui.search-filter.scss
@@ -62,7 +62,7 @@
 
   &__clear {
     margin: 0;
-    padding: 0 var(--spacer-sm) var(--spacer-sm);
+    padding: 0 var(--spacer-s) var(--spacer-s);
     text-align: center;
   }
 

--- a/src/styles/aui/_aui.sidebar.scss
+++ b/src/styles/aui/_aui.sidebar.scss
@@ -24,7 +24,7 @@ $sidebar-width: 20rem;
     width: $sidebar-width;
 
     &--padding {
-      padding: var(--spacer-lg);
+      padding: var(--spacer-xl);
     }
   }
 

--- a/src/styles/aui/_aui.statusbar.scss
+++ b/src/styles/aui/_aui.statusbar.scss
@@ -54,7 +54,7 @@
     }
 
     @include at($screen-lg) {
-      padding: var(--spacer-xs) var(--spacer-xx);
+      padding: var(--spacer-xs) var(--spacer-3xl);
     }
 
     p {

--- a/src/styles/aui/_aui.statusbar.scss
+++ b/src/styles/aui/_aui.statusbar.scss
@@ -50,7 +50,7 @@
     }
 
     @include at($screen-md) {
-      padding: var(--spacer-xs) var(--spacer-lg);
+      padding: var(--spacer-xs) var(--spacer-xl);
     }
 
     @include at($screen-lg) {

--- a/src/styles/aui/_aui.statusbar.scss
+++ b/src/styles/aui/_aui.statusbar.scss
@@ -46,7 +46,7 @@
     padding: var(--spacer-xs);
 
     @include at($screen-sm) {
-      padding: var(--spacer-xs) var(--spacer-md);
+      padding: var(--spacer-xs) var(--spacer-l);
     }
 
     @include at($screen-md) {

--- a/src/styles/aui/_aui.table.scss
+++ b/src/styles/aui/_aui.table.scss
@@ -65,7 +65,7 @@
   &__filters {
     flex: 1;
     margin-right: var(--spacer);
-    min-height: var(--spacer-xl);
+    min-height: var(--spacer-xxl);
     overflow: hidden;
 
     &-show-more {

--- a/src/styles/molecules/_molecules.accordion.scss
+++ b/src/styles/molecules/_molecules.accordion.scss
@@ -9,7 +9,7 @@ $accordion-header-bg-hover:   $background-color-light !default;
 $accordion-content-bg:        $accordion-header-bg !default;
 $accordion-icon-color:        $brand-primary !default;
 $accordion-icon-size:         $icon-size-sm !default;
-$accordion-header-padding:    var(--spacer-xs) var(--spacer-lg) var(--spacer-xs) var(--spacer-xs) !default;
+$accordion-header-padding:    var(--spacer-xs) var(--spacer-xl) var(--spacer-xs) var(--spacer-xs) !default;
 $accordion-content-padding:   var(--spacer) !default;
 
 
@@ -52,7 +52,7 @@ $accordion-content-padding:   var(--spacer) !default;
   border: 1px solid $accordion-border;
   cursor: pointer;
   display: flex;
-  min-height: var(--spacer-lg);
+  min-height: var(--spacer-xl);
   padding: $accordion-header-padding;
   position: relative;
   text-align: left;
@@ -73,7 +73,7 @@ $accordion-content-padding:   var(--spacer) !default;
     right: 0;
     top: 50%;
     transform: translateY(-50%);
-    width: var(--spacer-lg);
+    width: var(--spacer-xl);
   }
 }
 

--- a/src/styles/molecules/_molecules.alert.scss
+++ b/src/styles/molecules/_molecules.alert.scss
@@ -25,7 +25,7 @@ $alert-padding:           var(--spacer) !default;
     top: 0;
 
     + * {
-      margin-right: var(--spacer-md);
+      margin-right: var(--spacer-l);
     }
   }
 }

--- a/src/styles/molecules/_molecules.datepicker.scss
+++ b/src/styles/molecules/_molecules.datepicker.scss
@@ -32,7 +32,7 @@ $datepicker-unavailable-bg:          $datepicker-bg !default;
 .m-datepicker {
   max-width: calc(var(--spacer) * 14);
   opacity: 0;
-  transform: translateY(calc(var(--spacer-lg) * -1));
+  transform: translateY(calc(var(--spacer-xl) * -1));
   transition: visibility 0s $animation-duration $animation-easing, opacity $animation-normal, transform $animation-normal;
   visibility: hidden;
 
@@ -53,7 +53,7 @@ $datepicker-unavailable-bg:          $datepicker-bg !default;
 
 .m-datepicker__nav {
   display: flex;
-  height: var(--spacer-lg);
+  height: var(--spacer-xl);
 }
 
 .m-datepicker__title {
@@ -64,7 +64,7 @@ $datepicker-unavailable-bg:          $datepicker-bg !default;
   background-color: $datepicker-bg;
   border-left: 1px solid $datepicker-border;
   border-right: 1px solid $datepicker-border;
-  height: var(--spacer-lg);
+  height: var(--spacer-xl);
 }
 
 .m-datepicker__calendar {

--- a/src/styles/molecules/_molecules.flyout.scss
+++ b/src/styles/molecules/_molecules.flyout.scss
@@ -34,7 +34,7 @@ $flyout-max-height:       calc(var(--spacer) * 9) !default;
   box-shadow: $box-shadow;
   opacity: 0;
   position: absolute;
-  transform: translateY(calc(var(--spacer-lg) * -1));
+  transform: translateY(calc(var(--spacer-xl) * -1));
   transition: visibility 0s $animation-duration $animation-easing, opacity $animation-normal, transform $animation-normal;
   visibility: hidden;
   z-index: layer('flyout');

--- a/src/styles/molecules/_molecules.icon-list.scss
+++ b/src/styles/molecules/_molecules.icon-list.scss
@@ -23,7 +23,7 @@ $icon-list-icon-size:         $icon-size-base !default;
     text-align: center;
 
     &:not(:last-child) {
-      margin-bottom: var(--spacer-sm);
+      margin-bottom: var(--spacer-s);
     }
 
     a {

--- a/src/styles/molecules/_molecules.modal.scss
+++ b/src/styles/molecules/_molecules.modal.scss
@@ -32,7 +32,7 @@ $modal-padding:           var(--spacer) !default;
     top: 0;
 
     + * {
-      margin-right: var(--spacer-md);
+      margin-right: var(--spacer-l);
     }
   }
 }

--- a/src/styles/molecules/_molecules.navigation.scss
+++ b/src/styles/molecules/_molecules.navigation.scss
@@ -31,7 +31,7 @@ $nav-tab-color-disabled:      $nav-color-disabled !default;
   > li {
     font-weight: $nav-font-weight;
     line-height: $line-height-paragraph;
-    min-height: var(--spacer-lg);
+    min-height: var(--spacer-xl);
     text-align: center;
 
     > a,

--- a/src/styles/molecules/_molecules.pagination.scss
+++ b/src/styles/molecules/_molecules.pagination.scss
@@ -19,7 +19,7 @@ $pagination-outline-border:           $pagination-outline-color !default;
 $pagination-outline-border-hover:     mix($pagination-outline-border, $rich-black, 85%) !default;
 
 $pagination-size-sm:                  var(--spacer-md) !default;
-$pagination-size-lg:                  var(--spacer-xl) !default;
+$pagination-size-lg:                  var(--spacer-xxl) !default;
 
 
 /**

--- a/src/styles/molecules/_molecules.pagination.scss
+++ b/src/styles/molecules/_molecules.pagination.scss
@@ -4,7 +4,7 @@
  */
 
 $pagination-font-size:                $btn-font-size !default;
-$pagination-size:                     var(--spacer-lg) !default;
+$pagination-size:                     var(--spacer-xl) !default;
 
 $pagination-color:                    $btn-primary-color !default;
 $pagination-color-disabled:           $btn-disabled-color !default;

--- a/src/styles/molecules/_molecules.pagination.scss
+++ b/src/styles/molecules/_molecules.pagination.scss
@@ -18,7 +18,7 @@ $pagination-outline-bg-hover:         mix($pagination-outline-color, $white, 15%
 $pagination-outline-border:           $pagination-outline-color !default;
 $pagination-outline-border-hover:     mix($pagination-outline-border, $rich-black, 85%) !default;
 
-$pagination-size-sm:                  var(--spacer-md) !default;
+$pagination-size-sm:                  var(--spacer-l) !default;
 $pagination-size-lg:                  var(--spacer-xxl) !default;
 
 
@@ -163,7 +163,7 @@ $pagination-size-lg:                  var(--spacer-xxl) !default;
     }
 
     .m-pagination__label {
-      padding: 0 var(--spacer-md);
+      padding: 0 var(--spacer-l);
       width: auto;
     }
   }

--- a/src/styles/molecules/_molecules.progress.scss
+++ b/src/styles/molecules/_molecules.progress.scss
@@ -21,7 +21,7 @@ $progress-tooltip-bottom:   $progress-height - $progress-bar-padding + $tooltip-
 
 .m-progress__label {
   display: block;
-  margin-bottom: calc(var(--spacer-sm) / 2);
+  margin-bottom: calc(var(--spacer-s) / 2);
   text-align: left;
 }
 

--- a/src/styles/molecules/_molecules.progress.scss
+++ b/src/styles/molecules/_molecules.progress.scss
@@ -64,7 +64,7 @@ $progress-tooltip-bottom:   $progress-height - $progress-bar-padding + $tooltip-
   .m-progress__label {
     margin-bottom: 0;
     margin-right: var(--spacer-xs);
-    min-width: var(--spacer-md);
+    min-width: var(--spacer-l);
     text-align: right;
   }
 

--- a/src/styles/molecules/_molecules.step-indicator.scss
+++ b/src/styles/molecules/_molecules.step-indicator.scss
@@ -15,7 +15,7 @@ $step-indicator-color-success:          $white !default;
 $step-indicator-bg-success:             $state-success !default;
 $step-indicator-border-success:         $step-indicator-bg-success !default;
 $step-indicator-label-color-success:    $step-indicator-bg-success !default;
-$step-indicator-square-size:            var(--spacer-md) !default;
+$step-indicator-square-size:            var(--spacer-l) !default;
 
 
 /**

--- a/src/styles/molecules/_molecules.tag.scss
+++ b/src/styles/molecules/_molecules.tag.scss
@@ -8,7 +8,7 @@ $tag-bg:                  $background-color-light !default;
 $tag-border:              $border-color-light !default;
 $tag-border-focus:        $input-border-focus !default; // Remove this in a later version
 $tag-placeholder:         $input-placeholder !default;
-$tag-height:              var(--spacer-md) !default;
+$tag-height:              var(--spacer-l) !default;
 
 
 /**

--- a/src/styles/molecules/_molecules.upload.scss
+++ b/src/styles/molecules/_molecules.upload.scss
@@ -133,7 +133,7 @@ $upload-file-color-danger:    mix($rich-black, $state-danger, 40%) !default;
     color: $upload-file-color;
     line-height: $line-height-paragraph;
     min-height: var(--spacer-md);
-    padding: calc(var(--spacer) / 3) var(--spacer-lg) calc(var(--spacer) / 3) var(--spacer-lg);
+    padding: calc(var(--spacer) / 3) var(--spacer-xl) calc(var(--spacer) / 3) var(--spacer-xl);
     position: relative;
 
     &:not(:last-child) {

--- a/src/styles/molecules/_molecules.upload.scss
+++ b/src/styles/molecules/_molecules.upload.scss
@@ -4,7 +4,7 @@
  */
 
 $upload-height:              calc(var(--spacer) * 5) !default;
-$upload-padding:             var(--spacer-md) var(--spacer) !default;
+$upload-padding:             var(--spacer-l) var(--spacer) !default;
 
 $upload-color:               $text-color !default;
 $upload-bg:                  $white !default;
@@ -132,7 +132,7 @@ $upload-file-color-danger:    mix($rich-black, $state-danger, 40%) !default;
     background-color: $upload-file-bg;
     color: $upload-file-color;
     line-height: $line-height-paragraph;
-    min-height: var(--spacer-md);
+    min-height: var(--spacer-l);
     padding: calc(var(--spacer) / 3) var(--spacer-xl) calc(var(--spacer) / 3) var(--spacer-xl);
     position: relative;
 

--- a/src/styles/molecules/_molecules.upload.scss
+++ b/src/styles/molecules/_molecules.upload.scss
@@ -141,7 +141,7 @@ $upload-file-color-danger:    mix($rich-black, $state-danger, 40%) !default;
     }
 
     > .ai {
-      left: var(--spacer-sm);
+      left: var(--spacer-s);
       position: absolute;
       top: calc(var(--spacer) / 4 * 3);
       transform: translateY(-50%);

--- a/src/styles/organisms/_organisms.article.scss
+++ b/src/styles/organisms/_organisms.article.scss
@@ -6,11 +6,11 @@
 $article-h1-font-family:    $font-family-headings !default;
 $article-h1-font-size:      $font-size-h2 !default;
 $article-h1-font-weight:    normal !default;
-$article-h1-margin:         var(--spacer-lg) 0 var(--spacer) !default;
+$article-h1-margin:         var(--spacer-xl) 0 var(--spacer) !default;
 $article-h2-font-family:    $font-family-headings !default;
 $article-h2-font-size:      $font-size-h3 !default;
 $article-h2-font-weight:    normal !default;
-$article-h2-margin:         var(--spacer-lg) 0 var(--spacer) !default;
+$article-h2-margin:         var(--spacer-xl) 0 var(--spacer) !default;
 $article-h3-font-family:    $font-family-base !default;
 $article-h3-font-size:      $font-size-h5 !default;
 $article-h3-font-weight:    $bold !default;

--- a/src/styles/organisms/_organisms.footer.scss
+++ b/src/styles/organisms/_organisms.footer.scss
@@ -55,7 +55,7 @@ $footer-line-height:      $line-height-paragraph !default;
 
   @include at($screen-sm) {
     font-size: rem($footer-font-size-lg);
-    padding: 0 var(--spacer-xl);
+    padding: 0 var(--spacer-xxl);
   }
 
   a {

--- a/src/styles/organisms/_organisms.footer.scss
+++ b/src/styles/organisms/_organisms.footer.scss
@@ -6,7 +6,7 @@
 $footer-bg:               $rich-black !default;
 $footer-color:            $white !default;
 
-$footer-height:           var(--spacer-lg) !default;
+$footer-height:           var(--spacer-xl) !default;
 
 $footer-font-size-sm:     $font-size-sm !default;
 $footer-font-size-lg:     $font-size-sm !default;

--- a/src/styles/organisms/_organisms.navigation-menu.scss
+++ b/src/styles/organisms/_organisms.navigation-menu.scss
@@ -257,7 +257,7 @@ $navigation-menu-animation-speed: $animation-duration !default;
         position: relative;
 
         .o-menu__link {
-          margin-left: var(--spacer-sm);
+          margin-left: var(--spacer-s);
         }
 
         .o-menu__tab-title {

--- a/src/styles/organisms/_organisms.navigation-menu.scss
+++ b/src/styles/organisms/_organisms.navigation-menu.scss
@@ -4,7 +4,7 @@
  */
 
 $navigation-menu-border:          $border-color-light !default;
-$navigation-menu-mobile-height:   var(--spacer-xl) !default;
+$navigation-menu-mobile-height:   var(--spacer-xxl) !default;
 $navigation-menu-pane-width:      20rem !default;
 $navigation-menu-undocked-width:  15rem !default;
 $navigation-menu-docked-width:    $header-height !default;

--- a/src/styles/organisms/_organisms.slideshow.scss
+++ b/src/styles/organisms/_organisms.slideshow.scss
@@ -91,11 +91,11 @@
   &.o-slideshow__prev--outside {
 
     @include at($screen-md) {
-      left: calc(var(--spacer-lg) * -1);
+      left: calc(var(--spacer-xl) * -1);
     }
 
     @include at($screen-lg) {
-      left: calc(var(--spacer-lg) / -3 * 4);
+      left: calc(var(--spacer-xl) / -3 * 4);
     }
   }
 }
@@ -106,11 +106,11 @@
   &.o-slideshow__next--outside {
 
     @include at($screen-md) {
-      right: calc(var(--spacer-lg) * -1);
+      right: calc(var(--spacer-xl) * -1);
     }
 
     @include at($screen-lg) {
-      right: calc(var(--spacer-lg) / -3 * 4);
+      right: calc(var(--spacer-xl) / -3 * 4);
     }
   }
 }

--- a/src/styles/organisms/_organisms.slideshow.scss
+++ b/src/styles/organisms/_organisms.slideshow.scss
@@ -62,7 +62,7 @@
   }
 
   @include at($screen-lg) {
-    font-size: var(--spacer-md);
+    font-size: var(--spacer-l);
   }
 
   &.has-icon {

--- a/src/styles/quarks/_quarks.css-properties.scss
+++ b/src/styles/quarks/_quarks.css-properties.scss
@@ -24,7 +24,7 @@
   --spacer-xxl:              calc(var(--spacer) * 2.5); // 60px
   --spacer-xl:               calc(var(--spacer) * 2); // 48px
   --spacer-l:                calc(var(--spacer) * 1.5); // 36px
-  --spacer-sm:               calc(var(--spacer) * .75); // 18px
+  --spacer-s:                calc(var(--spacer) * .75); // 18px
   --spacer-xs:               calc(var(--spacer) * .5); // 12px
 
 

--- a/src/styles/quarks/_quarks.css-properties.scss
+++ b/src/styles/quarks/_quarks.css-properties.scss
@@ -22,7 +22,7 @@
 
   --spacer-3xl:              calc(var(--spacer) * 4); // 96px
   --spacer-xxl:              calc(var(--spacer) * 2.5); // 60px
-  --spacer-lg:               calc(var(--spacer) * 2); // 48px
+  --spacer-xl:               calc(var(--spacer) * 2); // 48px
   --spacer-md:               calc(var(--spacer) * 1.5); // 36px
   --spacer-sm:               calc(var(--spacer) * .75); // 18px
   --spacer-xs:               calc(var(--spacer) * .5); // 12px

--- a/src/styles/quarks/_quarks.css-properties.scss
+++ b/src/styles/quarks/_quarks.css-properties.scss
@@ -34,21 +34,21 @@
    */
 
   --screen-xs:               30rem; // 480px
-  --screen-sm:               45rem; // 720px
-  --screen-md:               62rem; // 992px
-  --screen-lg:               75rem; // 1200px
+  --screen-s:                45rem; // 720px
+  --screen-l:                62rem; // 992px
+  --screen-xl:               75rem; // 1200px
   /**
-   * --screen-xl =
+   * --screen-xxl =
    *    max-width of u-container
    *    + width of official logo * 2
    *    + space between logo and u-container * 2
    */
-  --screen-xl:               calc(var(--screen-lg) + calc(var(--spacer-3xl) * 2) + calc(var(--spacer) * 2)); // 90rem - 1440px
+  --screen-xxl:              calc(var(--screen-xl) + calc(var(--spacer-3xl) * 2) + calc(var(--spacer) * 2)); // 90rem - 1440px
 
-  --screen-xs-max:           44.9375rem; // 719px (--screen-sm - 1px)
-  --screen-sm-max:           61.9375rem; // 991px (--screen-md - 1px)
-  --screen-md-max:           74.9375rem; // 1199px (--screen-lg - 1px)
-  --screen-lg-max:           89.9375rem; // 1439px (--screen-xl - 1px)
+  --screen-xs-max:           44.9375rem; // 719px (--screen-s - 1px)
+  --screen-s-max:            61.9375rem; // 991px (--screen-l - 1px)
+  --screen-l-max:            74.9375rem; // 1199px (--screen-xl - 1px)
+  --screen-xl-max:           89.9375rem; // 1439px (--screen-xxl - 1px)
 
 
   /**

--- a/src/styles/quarks/_quarks.css-properties.scss
+++ b/src/styles/quarks/_quarks.css-properties.scss
@@ -21,7 +21,7 @@
   --spacer:                  1.5rem; // 24px
 
   --spacer-3xl:              calc(var(--spacer) * 4); // 96px
-  --spacer-xl:               calc(var(--spacer) * 2.5); // 60px
+  --spacer-xxl:              calc(var(--spacer) * 2.5); // 60px
   --spacer-lg:               calc(var(--spacer) * 2); // 48px
   --spacer-md:               calc(var(--spacer) * 1.5); // 36px
   --spacer-sm:               calc(var(--spacer) * .75); // 18px

--- a/src/styles/quarks/_quarks.css-properties.scss
+++ b/src/styles/quarks/_quarks.css-properties.scss
@@ -23,7 +23,7 @@
   --spacer-3xl:              calc(var(--spacer) * 4); // 96px
   --spacer-xxl:              calc(var(--spacer) * 2.5); // 60px
   --spacer-xl:               calc(var(--spacer) * 2); // 48px
-  --spacer-md:               calc(var(--spacer) * 1.5); // 36px
+  --spacer-l:                calc(var(--spacer) * 1.5); // 36px
   --spacer-sm:               calc(var(--spacer) * .75); // 18px
   --spacer-xs:               calc(var(--spacer) * .5); // 12px
 

--- a/src/styles/quarks/_quarks.css-properties.scss
+++ b/src/styles/quarks/_quarks.css-properties.scss
@@ -20,7 +20,7 @@
 
   --spacer:                  1.5rem; // 24px
 
-  --spacer-xx:               calc(var(--spacer) * 4); // 96px
+  --spacer-3xl:              calc(var(--spacer) * 4); // 96px
   --spacer-xl:               calc(var(--spacer) * 2.5); // 60px
   --spacer-lg:               calc(var(--spacer) * 2); // 48px
   --spacer-md:               calc(var(--spacer) * 1.5); // 36px
@@ -43,7 +43,7 @@
    *    + width of official logo * 2
    *    + space between logo and u-container * 2
    */
-  --screen-xl:               calc(var(--screen-lg) + calc(var(--spacer-xx) * 2) + calc(var(--spacer) * 2)); // 90rem - 1440px
+  --screen-xl:               calc(var(--screen-lg) + calc(var(--spacer-3xl) * 2) + calc(var(--spacer) * 2)); // 90rem - 1440px
 
   --screen-xs-max:           44.9375rem; // 719px (--screen-sm - 1px)
   --screen-sm-max:           61.9375rem; // 991px (--screen-md - 1px)

--- a/src/styles/styleguide.scss
+++ b/src/styles/styleguide.scss
@@ -92,8 +92,8 @@
   }
 
   @include at($screen-xs) {
-    padding-bottom: var(--spacer-md);
-    padding-top: var(--spacer-md);
+    padding-bottom: var(--spacer-l);
+    padding-top: var(--spacer-l);
   }
 }
 

--- a/src/styles/styleguide.scss
+++ b/src/styles/styleguide.scss
@@ -334,7 +334,7 @@
   padding-top: var(--spacer-lg);
 
   .o-menu {
-    margin-bottom: calc(var(--spacer-xx) * -1);
+    margin-bottom: calc(var(--spacer-3xl) * -1);
   }
 
   @include at($screen-sm) {

--- a/src/styles/styleguide.scss
+++ b/src/styles/styleguide.scss
@@ -338,7 +338,7 @@
   }
 
   @include at($screen-sm) {
-    padding-bottom: var(--spacer-xl);
+    padding-bottom: var(--spacer-xxl);
     padding-top: 0;
 
     .o-menu {

--- a/src/styles/styleguide.scss
+++ b/src/styles/styleguide.scss
@@ -114,7 +114,7 @@
 }
 
 .m-alert--wcag {
-  padding-left: var(--spacer-lg);
+  padding-left: var(--spacer-xl);
   position: relative;
 
   &:before {
@@ -331,7 +331,7 @@
 }
 
 .d--with-overlay {
-  padding-top: var(--spacer-lg);
+  padding-top: var(--spacer-xl);
 
   .o-menu {
     margin-bottom: calc(var(--spacer-3xl) * -1);
@@ -362,7 +362,7 @@
 
   &__row {
     display: grid;
-    grid-template-columns: var(--spacer-lg) auto;
+    grid-template-columns: var(--spacer-xl) auto;
     margin-bottom: calc(var(--spacer-xs) / 2); // [*GG]
 
     @include at($screen-sm) {

--- a/src/styles/utilities/_utilities.spacing.scss
+++ b/src/styles/utilities/_utilities.spacing.scss
@@ -19,7 +19,7 @@
 }
 
 .u-margin-md {
-  margin: var(--spacer-md) !important;
+  margin: var(--spacer-l) !important;
 }
 
 .u-margin {
@@ -53,7 +53,7 @@
 }
 
 .u-margin-top-md {
-  margin-top: var(--spacer-md) !important;
+  margin-top: var(--spacer-l) !important;
 }
 
 .u-margin-top {
@@ -87,7 +87,7 @@
 }
 
 .u-margin-right-md {
-  margin-right: var(--spacer-md) !important;
+  margin-right: var(--spacer-l) !important;
 }
 
 .u-margin-right {
@@ -121,7 +121,7 @@
 }
 
 .u-margin-bottom-md {
-  margin-bottom: var(--spacer-md) !important;
+  margin-bottom: var(--spacer-l) !important;
 }
 
 .u-margin-bottom {
@@ -154,7 +154,7 @@
 }
 
 .u-margin-left-md {
-  margin-left: var(--spacer-md) !important;
+  margin-left: var(--spacer-l) !important;
 }
 
 .u-margin-left {

--- a/src/styles/utilities/_utilities.spacing.scss
+++ b/src/styles/utilities/_utilities.spacing.scss
@@ -27,7 +27,7 @@
 }
 
 .u-margin-sm {
-  margin: var(--spacer-sm) !important;
+  margin: var(--spacer-s) !important;
 }
 
 .u-margin-xs {
@@ -61,7 +61,7 @@
 }
 
 .u-margin-top-sm {
-  margin-top: var(--spacer-sm) !important;
+  margin-top: var(--spacer-s) !important;
 }
 
 .u-margin-top-xs {
@@ -95,7 +95,7 @@
 }
 
 .u-margin-right-sm {
-  margin-right: var(--spacer-sm) !important;
+  margin-right: var(--spacer-s) !important;
 }
 
 .u-margin-right-xs {
@@ -129,7 +129,7 @@
 }
 
 .u-margin-bottom-sm {
-  margin-bottom: var(--spacer-sm) !important;
+  margin-bottom: var(--spacer-s) !important;
 }
 
 .u-margin-bottom-xs {
@@ -162,7 +162,7 @@
 }
 
 .u-margin-left-sm {
-  margin-left: var(--spacer-sm) !important;
+  margin-left: var(--spacer-s) !important;
 }
 
 .u-margin-left-xs {

--- a/src/styles/utilities/_utilities.spacing.scss
+++ b/src/styles/utilities/_utilities.spacing.scss
@@ -11,7 +11,7 @@
  */
 
 .u-margin-xx {
-  margin: var(--spacer-xx) !important;
+  margin: var(--spacer-3xl) !important;
 }
 
 .u-margin-lg {
@@ -45,7 +45,7 @@
  */
 
 .u-margin-top-xx {
-  margin-top: var(--spacer-xx) !important;
+  margin-top: var(--spacer-3xl) !important;
 }
 
 .u-margin-top-lg {
@@ -79,7 +79,7 @@
  */
 
 .u-margin-right-xx {
-  margin-right: var(--spacer-xx) !important;
+  margin-right: var(--spacer-3xl) !important;
 }
 
 .u-margin-right-lg {
@@ -113,7 +113,7 @@
  */
 
 .u-margin-bottom-xx {
-  margin-bottom: var(--spacer-xx) !important;
+  margin-bottom: var(--spacer-3xl) !important;
 }
 
 .u-margin-bottom-lg {
@@ -146,7 +146,7 @@
  */
 
 .u-margin-left-xx {
-  margin-left: var(--spacer-xx) !important;
+  margin-left: var(--spacer-3xl) !important;
 }
 
 .u-margin-left-lg {

--- a/src/styles/utilities/_utilities.spacing.scss
+++ b/src/styles/utilities/_utilities.spacing.scss
@@ -15,7 +15,7 @@
 }
 
 .u-margin-lg {
-  margin: var(--spacer-lg) !important;
+  margin: var(--spacer-xl) !important;
 }
 
 .u-margin-md {
@@ -49,7 +49,7 @@
 }
 
 .u-margin-top-lg {
-  margin-top: var(--spacer-lg) !important;
+  margin-top: var(--spacer-xl) !important;
 }
 
 .u-margin-top-md {
@@ -83,7 +83,7 @@
 }
 
 .u-margin-right-lg {
-  margin-right: var(--spacer-lg) !important;
+  margin-right: var(--spacer-xl) !important;
 }
 
 .u-margin-right-md {
@@ -117,7 +117,7 @@
 }
 
 .u-margin-bottom-lg {
-  margin-bottom: var(--spacer-lg) !important;
+  margin-bottom: var(--spacer-xl) !important;
 }
 
 .u-margin-bottom-md {
@@ -150,7 +150,7 @@
 }
 
 .u-margin-left-lg {
-  margin-left: var(--spacer-lg) !important;
+  margin-left: var(--spacer-xl) !important;
 }
 
 .u-margin-left-md {


### PR DESCRIPTION
Ik heb de spacer CSS properties hernoemd rekening houdend met de universele t-shirt size chart. 🙂 

```
--spacer-xx => --spacer-3xl // 96px
--spacer-xl => --spacer-xxl // 60px
--spacer-lg => --spacer-xl  // 48px
--spacer-md => --spacer-l   // 36px

--spacer                    // 24px

--spacer-sm => --spacer-s   // 18px
--spacer-xs                 // 12px
```

Ik ga nu de classes, vb. `u-margin-top-sm`, hernoemen naargelang dezelfde logica. 🙂 