### PR TITLE
Rework regular buttons with CSS props

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 
 ##### Changed
 - [BREAKING] Changed various CSS classes:
+  - Changed `.a-button--default` to `.a-button--neutral`
   - Changed `.a-button--tiny` to `.a-button--xs`
   - Changed `.a-button--small` to `.a-button--s`
   - Changed `.a-button--large` to `.a-button--l`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@
 
 ##### Changed
 - [BREAKING] Changed various CSS classes:
-  - Removed `.a-button--secondary`
   - Removed `.a-button--transparent`
   - Changed `.a-button--default` to `.a-button--neutral`
   - Changed `.a-button--tiny` to `.a-button--xs`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@
 
 ##### Changed
 - [BREAKING] Changed various CSS classes:
+  - Removed `.a-button--secondary`
+  - Removed `.a-button--transparent`
   - Changed `.a-button--default` to `.a-button--neutral`
   - Changed `.a-button--tiny` to `.a-button--xs`
   - Changed `.a-button--small` to `.a-button--s`

--- a/src/index.njk
+++ b/src/index.njk
@@ -125,7 +125,7 @@
         <footer class="o-footer u-margin-top-3xl">
             <span class="o-footer__label">© stad Antwerpen</span>
 
-            <a href="#" class="o-footer__button a-button has-icon" aria-label="Go back to top">
+            <a href="#" class="o-footer__button a-button a-button--secondary has-icon" aria-label="Go back to top">
                 {{ icon.render('arrow-up-1') }}
             </a>
         </footer>

--- a/src/index.njk
+++ b/src/index.njk
@@ -125,7 +125,7 @@
         <footer class="o-footer u-margin-top-3xl">
             <span class="o-footer__label">© stad Antwerpen</span>
 
-            <a href="#" class="o-footer__button a-button a-button--secondary has-icon" aria-label="Go back to top">
+            <a href="#" class="o-footer__button a-button has-icon" aria-label="Go back to top">
                 {{ icon.render('arrow-up-1') }}
             </a>
         </footer>

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -20,10 +20,6 @@
   --btn-neutral-bg-color:           #{$gray-400};
   --btn-neutral-hover-bg-color:     #{$gray-500};
 
-  --btn-secondary-color:            #{$white};
-  --btn-secondary-bg-color:         var(--theme2-400);
-  --btn-secondary-hover-bg-color:   var(--theme2-500);
-
   --btn-success-color:              #{$white};
   --btn-success-bg-color:           var(--success-600);
   --btn-success-hover-bg-color:     var(--success-500); // TODO: Implement correct hover state
@@ -110,12 +106,6 @@
     --btn-color: var(--btn-neutral-color);
     --btn-bg-color: var(--btn-neutral-bg-color);
     --btn-hover-bg-color: var(--btn-neutral-hover-bg-color);
-  }
-
-  &.a-button--secondary {
-    --btn-color: var(--btn-secondary-color);
-    --btn-bg-color: var(--btn-secondary-bg-color);
-    --btn-hover-bg-color: var(--btn-secondary-hover-bg-color);
   }
 
   &.a-button--success {

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -7,6 +7,40 @@
  */
 
 /**
+ * BUTTON VARIABLES
+ * -------------------------------------------------------------------
+ */
+
+.a-button {
+  --btn-color:                      #{$white};
+  --btn-bg-color:                   #{$gray-400};
+  --btn-hover-bg-color:             #{$gray-500};
+
+  --btn-primary-color:              #{$white};
+  --btn-primary-bg-color:           var(--theme1-400);
+  --btn-primary-hover-bg-color:     var(--theme1-500);
+
+  --btn-secondary-color:            #{$white};
+  --btn-secondary-bg-color:         var(--theme2-400);
+  --btn-secondary-hover-bg-color:   var(--theme2-500);
+
+  --btn-success-color:              #{$white};
+  --btn-success-bg-color:           var(--success-600);
+  --btn-success-hover-bg-color:     var(--success-500); // TODO: Implement correct hover state
+
+  --btn-warning-color:              #{$gray-600};
+  --btn-warning-bg-color:           var(--warning-500);
+  --btn-warning-hover-bg-color:     var(--warning-600);
+
+  --btn-danger-color:               #{$white};
+  --btn-danger-bg-color:            var(--danger-500);
+  --btn-danger-hover-bg-color:      var(--danger-600);
+
+  --btn-disabled-color:             #{$gray-400};
+  --btn-disabled-bg-color:          #{$gray-100};
+}
+
+/**
  * BUTTON PLACEHOLDER
  * -------------------------------------------------------------------
  */
@@ -56,28 +90,50 @@
  */
 
 .a-button {
-  @include a-button;
+  background-color: var(--btn-bg-color);
+  color: var(--btn-color);
+
+  &:hover,
+  &:active,
+  &:focus {
+    background-color: var(--btn-hover-bg-color);
+    text-decoration: none;
+  }
+
+  &:disabled {
+    background-color: var(--btn-disabled-bg-color);
+    color: var(--btn-disabled-color);
+    cursor: not-allowed;
+  }
+
+  &.a-button--primary {
+    --btn-color: var(--btn-primary-color);
+    --btn-bg-color: var(--btn-primary-bg-color);
+    --btn-hover-bg-color: var(--btn-primary-hover-bg-color);
+  }
 
   &.a-button--secondary {
-    @include a-button($btn-secondary-color, $btn-secondary-bg);
+    --btn-color: var(--btn-secondary-color);
+    --btn-bg-color: var(--btn-secondary-bg-color);
+    --btn-hover-bg-color: var(--btn-secondary-hover-bg-color);
   }
 
   &.a-button--success {
-    @include a-button($btn-success-color, $btn-success-bg);
+    --btn-color: var(--btn-success-color);
+    --btn-bg-color: var(--btn-success-bg-color);
+    --btn-hover-bg-color: var(--btn-success-hover-bg-color);
   }
 
   &.a-button--warning {
-    @include a-button($btn-warning-color, $btn-warning-bg);
+    --btn-color: var(--btn-warning-color);
+    --btn-bg-color: var(--btn-warning-bg-color);
+    --btn-hover-bg-color: var(--btn-warning-hover-bg-color);
   }
 
   &.a-button--danger {
-    @include a-button($btn-danger-color, $btn-danger-bg);
-  }
-
-  &.a-button--transparent {
-    @include a-button($btn-transparent-color, $btn-transparent-bg);
-
-    text-decoration: underline;
+    --btn-color: var(--btn-danger-color);
+    --btn-bg-color: var(--btn-danger-bg-color);
+    --btn-hover-bg-color: var(--btn-danger-hover-bg-color);
   }
 }
 

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -20,6 +20,10 @@
   --btn-neutral-bg-color:           #{$gray-400};
   --btn-neutral-hover-bg-color:     #{$gray-500};
 
+  --btn-secondary-color:            #{$white};
+  --btn-secondary-bg-color:         var(--theme2-400);
+  --btn-secondary-hover-bg-color:   var(--theme2-500);
+
   --btn-success-color:              #{$white};
   --btn-success-bg-color:           var(--success-600);
   --btn-success-hover-bg-color:     var(--success-500); // TODO: Implement correct hover state
@@ -107,6 +111,12 @@
     --btn-color: var(--btn-neutral-color);
     --btn-bg-color: var(--btn-neutral-bg-color);
     --btn-hover-bg-color: var(--btn-neutral-hover-bg-color);
+  }
+
+  &.a-button--secondary {
+    --btn-color: var(--btn-secondary-color);
+    --btn-bg-color: var(--btn-secondary-bg-color);
+    --btn-hover-bg-color: var(--btn-secondary-hover-bg-color);
   }
 
   &.a-button--success {

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -47,7 +47,7 @@
 
 %a-button {
   border: none;
-  border-radius: 0;
+  border-radius: var(--border-radius);
   cursor: pointer;
   display: block;
   font-size: rem($btn-font-size);

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -13,12 +13,12 @@
 
 .a-button {
   --btn-color:                      #{$white};
-  --btn-bg-color:                   #{$gray-400};
-  --btn-hover-bg-color:             #{$gray-500};
+  --btn-bg-color:                   var(--theme1-400);
+  --btn-hover-bg-color:             var(--theme1-500);
 
-  --btn-primary-color:              #{$white};
-  --btn-primary-bg-color:           var(--theme1-400);
-  --btn-primary-hover-bg-color:     var(--theme1-500);
+  --btn-neutral-color:              #{$white};
+  --btn-neutral-bg-color:           #{$gray-400};
+  --btn-neutral-hover-bg-color:     #{$gray-500};
 
   --btn-secondary-color:            #{$white};
   --btn-secondary-bg-color:         var(--theme2-400);
@@ -106,10 +106,10 @@
     cursor: not-allowed;
   }
 
-  &.a-button--primary {
-    --btn-color: var(--btn-primary-color);
-    --btn-bg-color: var(--btn-primary-bg-color);
-    --btn-hover-bg-color: var(--btn-primary-hover-bg-color);
+  &.a-button--neutral {
+    --btn-color: var(--btn-neutral-color);
+    --btn-bg-color: var(--btn-neutral-bg-color);
+    --btn-hover-bg-color: var(--btn-neutral-hover-bg-color);
   }
 
   &.a-button--secondary {

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -93,6 +93,7 @@
   &:active,
   &:focus {
     background-color: var(--btn-hover-bg-color);
+    color: var(--btn-color);
     text-decoration: none;
   }
 

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -137,10 +137,6 @@
   }
 }
 
-.a-button.has-icon.a-button--default {
-  @include a-button($btn-default-color, $btn-default-bg);
-}
-
 /**
  * SOCIAL BUTTON COLORS
  * -------------------------------------------------------------------

--- a/src/styles/molecules/_molecules.button-group.scss
+++ b/src/styles/molecules/_molecules.button-group.scss
@@ -33,6 +33,10 @@
       border-right: none;
     }
 
+    &.a-button--secondary {
+      border-color: mix($btn-secondary-bg, $black, 85%);
+    }
+
     &.a-button--success {
       border-color: mix($btn-success-bg, $black, 85%);
     }

--- a/src/styles/molecules/_molecules.button-group.scss
+++ b/src/styles/molecules/_molecules.button-group.scss
@@ -33,10 +33,6 @@
       border-right: none;
     }
 
-    &.a-button--secondary {
-      border-color: mix($btn-secondary-bg, $black, 85%);
-    }
-
     &.a-button--success {
       border-color: mix($btn-success-bg, $black, 85%);
     }

--- a/src/styles/molecules/_molecules.button-group.scss
+++ b/src/styles/molecules/_molecules.button-group.scss
@@ -44,10 +44,6 @@
     &.a-button--danger {
       border-color: mix($btn-danger-bg, $black, 85%);
     }
-
-    &.a-button--transparent {
-      border: none;
-    }
   }
 
   > .a-button-outline {

--- a/src/templates/atoms.njk
+++ b/src/templates/atoms.njk
@@ -211,10 +211,10 @@
         <h4 class="u-margin-top-xl">Contained buttons</h4>
         <div class="d">
             <div>
-                <button class="a-button">Neutral button</button>
+                <button class="a-button">Primary button</button>
             </div>
             <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button"&gt;Neutral button&lt;/button&gt;</code></pre>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button"&gt;Primary button&lt;/button&gt;</code></pre>
             </div>
         </div>
         <div class="d">
@@ -223,14 +223,6 @@
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button" disabled&gt;Disabled button&lt;/button&gt;</code></pre>
-            </div>
-        </div>
-        <div class="d">
-            <div>
-                <button class="a-button a-button--primary">Primary button</button>
-            </div>
-            <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--primary"&gt;Primary button&lt;/button&gt;</code></pre>
             </div>
         </div>
         <div class="d">

--- a/src/templates/atoms.njk
+++ b/src/templates/atoms.njk
@@ -615,7 +615,7 @@
         <div class="d">
             <div>
                 <div>
-                    <button class="a-button a-button--default has-icon" aria-label="Download">
+                    <button class="a-button a-button--neutral has-icon" aria-label="Download">
                         {{ icon.render('download-bottom') }}
                     </button>
                 </div>
@@ -626,7 +626,7 @@
                 </div>
             </div>
             <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--default has-icon" aria-label="Download"&gt;
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--neutral has-icon" aria-label="Download"&gt;
   {{ icon.code('download-bottom') }}
 &lt;/button&gt;</code></pre>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-transparent a-button--default has-icon" aria-label="Close"&gt;

--- a/src/templates/atoms.njk
+++ b/src/templates/atoms.njk
@@ -227,14 +227,6 @@
         </div>
         <div class="d">
             <div>
-                <button class="a-button a-button--secondary">Secondary button</button>
-            </div>
-            <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--secondary"&gt;Secondary button&lt;/button&gt;</code></pre>
-            </div>
-        </div>
-        <div class="d">
-            <div>
                 <button class="a-button a-button--success">Success button</button>
             </div>
             <div>

--- a/src/templates/atoms.njk
+++ b/src/templates/atoms.njk
@@ -208,13 +208,13 @@
         <a name="atoms-button" aria-label="Button"></a>
         <h3 class="u-margin-top-xl">Button</h3>
         <span class="d-file">atoms/atoms.button</span>
-        <h4 class="u-margin-top-xl">Regular buttons</h4>
+        <h4 class="u-margin-top-xl">Contained buttons</h4>
         <div class="d">
             <div>
-                <button class="a-button">Primary button</button>
+                <button class="a-button">Neutral button</button>
             </div>
             <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button"&gt;Primary button&lt;/button&gt;</code></pre>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button"&gt;Neutral button&lt;/button&gt;</code></pre>
             </div>
         </div>
         <div class="d">
@@ -222,7 +222,15 @@
                 <button class="a-button" disabled>Disabled button</button>
             </div>
             <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button" disabled&gt;Secondary button&lt;/button&gt;</code></pre>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button" disabled&gt;Disabled button&lt;/button&gt;</code></pre>
+            </div>
+        </div>
+        <div class="d">
+            <div>
+                <button class="a-button a-button--primary">Primary button</button>
+            </div>
+            <div>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--primary"&gt;Primary button&lt;/button&gt;</code></pre>
             </div>
         </div>
         <div class="d">
@@ -257,42 +265,8 @@
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--danger"&gt;Danger button&lt;/button&gt;</code></pre>
             </div>
         </div>
-        <div class="d">
-            <div>
-                <button class="a-button a-button--transparent">Transparent button</button>
-            </div>
-            <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--transparent"&gt;Transparent button&lt;/button&gt;</code></pre>
-            </div>
-        </div>
 
-        <h4 class="u-margin-top-xl">Negative buttons</h4>
-        <div class="d">
-            <div>
-                <button class="a-button-negative">Primary button</button>
-            </div>
-            <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative"&gt;Primary button&lt;/button&gt;</code></pre>
-            </div>
-        </div>
-        <div class="d">
-            <div>
-                <button class="a-button-negative" disabled>Disabled button</button>
-            </div>
-            <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative" disabled&gt;Secondary button&lt;/button&gt;</code></pre>
-            </div>
-        </div>
-        <div class="d">
-            <div>
-                <button class="a-button-negative a-button--secondary">Secondary button</button>
-            </div>
-            <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative a-button--secondary"&gt;Secondary button&lt;/button&gt;</code></pre>
-            </div>
-        </div>
-
-        <h4 class="u-margin-top-xl">Outline buttons</h4>
+        <h4 class="u-margin-top-xl">Outlined buttons</h4>
         <div class="d">
             <div>
                 <button class="a-button-outline">Primary button</button>
@@ -339,6 +313,32 @@
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-outline a-button--danger"&gt;Danger button&lt;/button&gt;</code></pre>
+            </div>
+        </div>
+
+        <h4 class="u-margin-top-xl">Text buttons</h4>
+        <div class="d">
+            <div>
+                <button class="a-button-negative">Primary button</button>
+            </div>
+            <div>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative"&gt;Primary button&lt;/button&gt;</code></pre>
+            </div>
+        </div>
+        <div class="d">
+            <div>
+                <button class="a-button-negative" disabled>Disabled button</button>
+            </div>
+            <div>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative" disabled&gt;Secondary button&lt;/button&gt;</code></pre>
+            </div>
+        </div>
+        <div class="d">
+            <div>
+                <button class="a-button-negative a-button--secondary">Secondary button</button>
+            </div>
+            <div>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative a-button--secondary"&gt;Secondary button&lt;/button&gt;</code></pre>
             </div>
         </div>
 

--- a/src/templates/molecules.njk
+++ b/src/templates/molecules.njk
@@ -2175,7 +2175,7 @@
             <div>
                 <div>
                     <div class="m-tag u-margin-bottom-xs">
-                        <button class="a-button a-button--default a-button--s has-icon" aria-label="Accept">{{ icon.render('check-1') }}</button>
+                        <button class="a-button a-button--neutral a-button--s has-icon" aria-label="Accept">{{ icon.render('check-1') }}</button>
                         <span class="m-tag__label">My tag with icon</span>
                     </div>
                 </div>
@@ -2188,7 +2188,7 @@
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div class="m-tag"&gt;
-  &lt;button class="a-button a-button--default a-button--s has-icon" aria-label="Accept"&gt;{{ icon.code('check-1') }}&lt;/button&gt;
+  &lt;button class="a-button a-button--neutral a-button--s has-icon" aria-label="Accept"&gt;{{ icon.code('check-1') }}&lt;/button&gt;
   &lt;span class="m-tag__label"&gt;My tag with icon&lt;/span&gt;
  &lt;/div&gt;</code></pre>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div class="m-tag"&gt;

--- a/src/templates/organisms.njk
+++ b/src/templates/organisms.njk
@@ -82,7 +82,7 @@
             <div>
                 <footer class="o-footer">
                     <span class="o-footer__label">© stad Antwerpen | <a href="javascript:void(0)">Privacy</a> | <a href="javascript:void(0)">Accessibility</a></span>
-                    <a href="javascript:void(0)" class="o-footer__button a-button has-icon" aria-label="Go back to top">
+                    <a href="javascript:void(0)" class="o-footer__button a-button a-button--secondary has-icon" aria-label="Go back to top">
                         {{ icon.render('arrow-up-1') }}
                     </a>
                 </footer>
@@ -90,7 +90,7 @@
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;footer class="o-footer"&gt;
   &lt;span class="o-footer__label"&gt;&copy; stad Antwerpen | &lt;a href="#"&gt;Privacy&lt;/a&gt; | &lt;a href="#"&gt;Accessibility&lt;/a&gt;&lt;/span&gt;
-  &lt;a href="#" class="o-footer__button a-button has-icon" aria-label="Go back to top"&gt;
+  &lt;a href="#" class="o-footer__button a-button a-button--secondary has-icon" aria-label="Go back to top"&gt;
     {{ icon.code('arrow-up-1', true, 'ai o-menu__icon o-menu__submenu-icon') }}
   &lt;/a&gt;
 &lt;/footer&gt;</code></pre>

--- a/src/templates/organisms.njk
+++ b/src/templates/organisms.njk
@@ -82,7 +82,7 @@
             <div>
                 <footer class="o-footer">
                     <span class="o-footer__label">© stad Antwerpen | <a href="javascript:void(0)">Privacy</a> | <a href="javascript:void(0)">Accessibility</a></span>
-                    <a href="javascript:void(0)" class="o-footer__button a-button a-button--secondary has-icon" aria-label="Go back to top">
+                    <a href="javascript:void(0)" class="o-footer__button a-button has-icon" aria-label="Go back to top">
                         {{ icon.render('arrow-up-1') }}
                     </a>
                 </footer>
@@ -90,7 +90,7 @@
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;footer class="o-footer"&gt;
   &lt;span class="o-footer__label"&gt;&copy; stad Antwerpen | &lt;a href="#"&gt;Privacy&lt;/a&gt; | &lt;a href="#"&gt;Accessibility&lt;/a&gt;&lt;/span&gt;
-  &lt;a href="#" class="o-footer__button a-button a-button--secondary has-icon" aria-label="Go back to top"&gt;
+  &lt;a href="#" class="o-footer__button a-button has-icon" aria-label="Go back to top"&gt;
     {{ icon.code('arrow-up-1', true, 'ai o-menu__icon o-menu__submenu-icon') }}
   &lt;/a&gt;
 &lt;/footer&gt;</code></pre>

--- a/src/templates/organisms.njk
+++ b/src/templates/organisms.njk
@@ -704,7 +704,7 @@
             <div>
                 <ul class="o-tag-list">
                     <li class="m-tag">
-                        <button class="a-button a-button--default a-button--s has-icon" aria-label="Accept">{{ icon.render('check-1') }}</button>
+                        <button class="a-button a-button--neutral a-button--s has-icon" aria-label="Accept">{{ icon.render('check-1') }}</button>
                         <span class="m-tag__label">Thomas Edison</span>
                     </li>
                     <li class="m-tag">
@@ -720,7 +720,7 @@
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;ul class="o-tag-list"&gt;
   &lt;li class="m-tag"&gt;
-    &lt;button class="a-button a-button--default a-button--s has-icon" aria-label="Accept"&gt;{{ icon.code('check-1') }}&lt;/button&gt;
+    &lt;button class="a-button a-button--neutral a-button--s has-icon" aria-label="Accept"&gt;{{ icon.code('check-1') }}&lt;/button&gt;
     &lt;span class="m-tag__label"&gt;Thomas Edison&lt;/span&gt;
   &lt;/li&gt;
   &lt;li class="m-tag"&gt;


### PR DESCRIPTION
Een eerste aanzet tot het implementeren van de herwerkte buttons. 

Momenteel heb ik me nog enkel gefocust op de regular buttons. Deze zijn nu uitgewerkt aan de hand van CSS props.

![Screenshot 2021-10-04 at 09 25 41](https://user-images.githubusercontent.com/4232875/135810293-836cb568-f751-4245-a3bb-97a2afbf8a91.png)

Ik heb de default `a-button` nu standaard donkergrijs gemaakt. Zie neutral button in XD-file. De blauwe button heeft nu de class `a-button--primary` gekregen. Dit leek mij de meest logische aanpak.

Het gevolg is wel dat veel molecules en organisms (vb. datepicker, flyout, button groups, etc.) die gebruikmaken van de `a-button` nu allemaal donkergrijs zijn. Dus vroeg me nog af of we die `a-button` wel willen veranderen van blauw naar donkergrijs. Misschien moet ik eerder een nieuwe class `a-button--neutral` aanmaken waarmee je dan de donkergrijze button mee kan vormen. Dan kunnen we `a-button` gewoon in de themakleur blijven tonen. 🤔 
