### PR TITLE
Text buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 ##### Changed
 - [BREAKING] Changed various CSS classes:
   - Changed `.a-button-outline` to `.a-button.a-button--outlined`
+  - Changed `.a-button-negative` to `.a-button.a-button--text`
   - Changed `.a-button--default` to `.a-button--neutral`
   - Removed `.a-button--tiny`
   - Changed `.a-button--small` to `.a-button--s`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
   - Removed `.a-button--secondary`
   - Removed `.a-button--transparent`
   - Removed `.a-button--tiny`
+  - Removed `.a-button-transparent`
   - Changed `.a-button-outline` to `.a-button.a-button--outlined`
   - Changed `.a-button-negative` to `.a-button.a-button--text`
   - Changed `.a-button--default` to `.a-button--neutral`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,11 @@
   - Changed `.m-flyout--md` to `.m-flyout--l`
   - Changed `.m-flyout--sm` to `.m-flyout--s`
 
+#### Header
+
+##### Changed
+- [BREAKING] `.o-header__button` requires additional classes: `a-button--text a-button--neutral`
+
 #### Input
 
 ##### Added

--- a/src/index.njk
+++ b/src/index.njk
@@ -75,7 +75,7 @@
 <body>
     <div role="banner">
         <header class="o-header" aria-label="Header">
-            <a href="#main-content" class="a-button-negative o-header__button o-header__button-skip">Skip to main content</a>
+            <a href="#main-content" class="a-button a-button--text o-header__button o-header__button-skip">Skip to main content</a>
             <a href="/" class="o-header__logo">
                 <img src="./images/a-logo.svg" alt="Homepage Antwerp branding styleguide.">
             </a>

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -162,7 +162,6 @@
 }
 
 .a-button,
-.a-button-transparent,
 .a-button-official {
   @extend %a-button;
 }
@@ -413,41 +412,11 @@
 }
 
 /**
- * BUTTON ICON TRANSPARENT COLORS
- * -------------------------------------------------------------------
- */
-
-.a-button-transparent.has-icon {
-  @include a-button-outline($btn-primary-outline-color, $btn-primary-outline-border, true);
-
-  &.a-button--secondary {
-    @include a-button-outline($btn-secondary-outline-color, $btn-secondary-outline-border, true);
-  }
-
-  &.a-button--success {
-    @include a-button-outline($btn-success-outline-color, $btn-success-outline-border, true);
-  }
-
-  &.a-button--warning {
-    @include a-button-outline($btn-warning-outline-color, $btn-warning-outline-border, true);
-  }
-
-  &.a-button--danger {
-    @include a-button-outline($btn-danger-outline-color, $btn-danger-outline-border, true);
-  }
-
-  &.a-button--default {
-    @include a-button-outline($btn-default-outline-color, $btn-default-outline-border, true);
-  }
-}
-
-/**
  * BUTTON SIZES
  * -------------------------------------------------------------------
  */
 
-.a-button,
-.a-button-transparent {
+.a-button {
   &.a-button--s {
     font-size: rem($btn-font-size-sm);
     min-height: var(--spacer-l);
@@ -474,8 +443,7 @@
  * -------------------------------------------------------------------
  */
 
-.a-button,
-.a-button-transparent {
+.a-button {
   &.has-icon-left,
   &.has-icon-right {
     position: relative;
@@ -540,22 +508,19 @@
  * -------------------------------------------------------------------
  */
 
-.a-button,
-.a-button-transparent {
-  &.has-icon {
-    display: inline-block;
-    padding: 0;
-    position: relative;
-    vertical-align: middle;
-    width: var(--spacer-xl);
+.a-button.has-icon {
+  display: inline-block;
+  padding: 0;
+  position: relative;
+  vertical-align: middle;
+  width: var(--spacer-xl);
 
-    .ai {
-      left: 0;
-      position: absolute;
-      top: 50%;
-      transform: translateY(-50%);
-      width: var(--spacer-xl);
-    }
+  .ai {
+    left: 0;
+    position: absolute;
+    top: 50%;
+    transform: translateY(-50%);
+    width: var(--spacer-xl);
   }
 }
 

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -99,12 +99,6 @@
   --btn-text-neutral-border-color:              transparent;
   --btn-text-neutral-hover-border-color:        transparent;
 
-  --btn-text-secondary-color:                   var(--theme2-400);
-  --btn-text-secondary-bg-color:                transparent;
-  --btn-text-secondary-hover-bg-color:          var(--theme2-100);
-  --btn-text-secondary-border-color:            transparent;
-  --btn-text-secondary-hover-border-color:      transparent;
-
   --btn-text-disabled-color:                    #{$gray-400};
   --btn-text-disabled-bg-color:                 #{$gray-100};
   --btn-text-disabled-hover-bg-color:           var(--btn-text-disabled-bg-color);
@@ -365,14 +359,6 @@
     --btn-hover-bg-color: var(--btn-text-neutral-hover-bg-color);
     --btn-border-color: var(--btn-text-neutral-border-color);
     --btn-hover-border-color: var(--btn-text-neutral-hover-border-color);
-  }
-
-  &.a-button--secondary {
-    --btn-color: var(--btn-text-secondary-color);
-    --btn-bg-color: var(--btn-text-secondary-bg-color);
-    --btn-hover-bg-color: var(--btn-text-secondary-hover-bg-color);
-    --btn-border-color: var(--btn-text-secondary-border-color);
-    --btn-hover-border-color: var(--btn-text-secondary-hover-border-color);
   }
 
   &:disabled {

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -182,6 +182,7 @@
   &:focus {
     background-color: var(--btn-hover-bg-color);
     box-shadow: 0 0 0 var(--border-width) var(--btn-hover-border-color) inset;
+    color: var(--btn-color);
     text-decoration: none;
   }
 

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -374,9 +374,9 @@
  */
 
 .a-button.a-button--text {
-  --btn-color: var(--btn-out-color);
-  --btn-bg-color: var(--btn-out-bg-color);
-  --btn-hover-bg-color: var(--btn-out-hover-bg-color);
+  --btn-color: var(--btn-text-color);
+  --btn-bg-color: var(--btn-text-bg-color);
+  --btn-hover-bg-color: var(--btn-text-hover-bg-color);
   --btn-border-color: var(--btn-text-border-color);
   --btn-hover-border-color: var(--btn-text-hover-border-color);
 

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -97,6 +97,25 @@
   --btn-outline-disabled-hover-bg-color:        var(--btn-outline-disabled-bg-color);
   --btn-outline-disabled-border-color:          #{$gray-200};
   --btn-outline-disabled-hover-border-color:    var(--btn-outline-disabled-border-color);
+
+  // Text buttons
+  --btn-text-color:                             var(--theme1-400);
+  --btn-text-bg-color:                          transparent;
+  --btn-text-hover-bg-color:                    var(--theme1-050);
+  --btn-text-border-color:                      transparent;
+  --btn-text-hover-border-color:                transparent;
+
+  --btn-text-secondary-color:                   var(--theme2-400);
+  --btn-text-secondary-bg-color:                transparent;
+  --btn-text-secondary-hover-bg-color:          var(--theme2-100);
+  --btn-text-secondary-border-color:            transparent;
+  --btn-text-secondary-hover-border-color:      transparent;
+
+  --btn-text-disabled-color:                    #{$gray-400};
+  --btn-text-disabled-bg-color:                 #{$gray-100};
+  --btn-text-disabled-hover-bg-color:           var(--btn-text-disabled-bg-color);
+  --btn-text-disabled-border-color:             var(--btn-text-disabled-bg-color);
+  --btn-text-disabled-hover-border-color:       var(--btn-text-disabled-bg-color);
 }
 
 /**
@@ -137,7 +156,6 @@
 }
 
 .a-button,
-.a-button-negative,
 .a-button-transparent,
 .a-button-official {
   @extend %a-button;
@@ -290,20 +308,7 @@
 }
 
 /**
- * BUTTON NEGATIVE COLORS
- * -------------------------------------------------------------------
- */
-
-.a-button-negative {
-  @include a-button($btn-primary-negative-color, $btn-primary-negative-bg);
-
-  &.a-button--secondary {
-    @include a-button($btn-secondary-negative-color, $btn-secondary-negative-bg);
-  }
-}
-
-/**
- * BUTTON OUTLINE COLORS
+ * OUTLINED BUTTON COLORS
  * -------------------------------------------------------------------
  */
 
@@ -364,6 +369,35 @@
 }
 
 /**
+ * TEXT BUTTON COLORS
+ * -------------------------------------------------------------------
+ */
+
+.a-button.a-button--text {
+  --btn-color: var(--btn-out-color);
+  --btn-bg-color: var(--btn-out-bg-color);
+  --btn-hover-bg-color: var(--btn-out-hover-bg-color);
+  --btn-border-color: var(--btn-text-border-color);
+  --btn-hover-border-color: var(--btn-text-hover-border-color);
+
+  &.a-button--secondary {
+    --btn-color: var(--btn-text-secondary-color);
+    --btn-bg-color: var(--btn-text-secondary-bg-color);
+    --btn-hover-bg-color: var(--btn-text-secondary-hover-bg-color);
+    --btn-border-color: var(--btn-text-secondary-border-color);
+    --btn-hover-border-color: var(--btn-text-secondary-hover-border-color);
+  }
+
+  &:disabled {
+    --btn-color: var(--btn-text-disabled-color);
+    --btn-bg-color: var(--btn-text-disabled-bg-color);
+    --btn-hover-bg-color: var(--btn-text-disabled-hover-bg-color);
+    --btn-border-color: var(--btn-text-disabled-border-color);
+    --btn-hover-border-color: var(--btn-text-disabled-hover-border-color);
+  }
+}
+
+/**
  * BUTTON ICON TRANSPARENT COLORS
  * -------------------------------------------------------------------
  */
@@ -398,7 +432,6 @@
  */
 
 .a-button,
-.a-button-negative,
 .a-button-transparent {
   &.a-button--s {
     font-size: rem($btn-font-size-sm);
@@ -427,7 +460,6 @@
  */
 
 .a-button,
-.a-button-negative,
 .a-button-transparent {
   &.has-icon-left,
   &.has-icon-right {
@@ -494,7 +526,6 @@
  */
 
 .a-button,
-.a-button-negative,
 .a-button-transparent {
   &.has-icon {
     display: inline-block;

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -99,6 +99,24 @@
   --btn-text-neutral-border-color:              transparent;
   --btn-text-neutral-hover-border-color:        transparent;
 
+  --btn-text-success-color:                     var(--success-600);
+  --btn-text-success-bg-color:                  transparent;
+  --btn-text-success-hover-bg-color:            var(--success-050);
+  --btn-text-success-border-color:              transparent;
+  --btn-text-success-hover-border-color:        transparent;
+
+  --btn-text-warning-color:                     #{$gray-600};
+  --btn-text-warning-bg-color:                  transparent;
+  --btn-text-warning-hover-bg-color:            var(--warning-050);
+  --btn-text-warning-border-color:              transparent;
+  --btn-text-warning-hover-border-color:        transparent;
+
+  --btn-text-danger-color:                      var(--danger-500);
+  --btn-text-danger-bg-color:                   transparent;
+  --btn-text-danger-hover-bg-color:             var(--danger-050);
+  --btn-text-danger-border-color:               transparent;
+  --btn-text-danger-hover-border-color:         transparent;
+
   --btn-text-disabled-color:                    #{$gray-400};
   --btn-text-disabled-bg-color:                 #{$gray-100};
   --btn-text-disabled-hover-bg-color:           var(--btn-text-disabled-bg-color);
@@ -359,6 +377,30 @@
     --btn-hover-bg-color: var(--btn-text-neutral-hover-bg-color);
     --btn-border-color: var(--btn-text-neutral-border-color);
     --btn-hover-border-color: var(--btn-text-neutral-hover-border-color);
+  }
+
+  &.a-button--success {
+    --btn-color: var(--btn-text-success-color);
+    --btn-bg-color: var(--btn-text-success-bg-color);
+    --btn-hover-bg-color: var(--btn-text-success-hover-bg-color);
+    --btn-border-color: var(--btn-text-success-border-color);
+    --btn-hover-border-color: var(--btn-text-success-hover-border-color);
+  }
+
+  &.a-button--warning {
+    --btn-color: var(--btn-text-warning-color);
+    --btn-bg-color: var(--btn-text-warning-bg-color);
+    --btn-hover-bg-color: var(--btn-text-warning-hover-bg-color);
+    --btn-border-color: var(--btn-text-warning-border-color);
+    --btn-hover-border-color: var(--btn-text-warning-hover-border-color);
+  }
+
+  &.a-button--danger {
+    --btn-color: var(--btn-text-danger-color);
+    --btn-bg-color: var(--btn-text-danger-bg-color);
+    --btn-hover-bg-color: var(--btn-text-danger-hover-bg-color);
+    --btn-border-color: var(--btn-text-danger-border-color);
+    --btn-hover-border-color: var(--btn-text-danger-hover-border-color);
   }
 
   &:disabled {

--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -105,6 +105,12 @@
   --btn-text-border-color:                      transparent;
   --btn-text-hover-border-color:                transparent;
 
+  --btn-text-neutral-color:                     #{$gray-400};
+  --btn-text-neutral-bg-color:                  transparent;
+  --btn-text-neutral-hover-bg-color:            #{$gray-100};
+  --btn-text-neutral-border-color:              transparent;
+  --btn-text-neutral-hover-border-color:        transparent;
+
   --btn-text-secondary-color:                   var(--theme2-400);
   --btn-text-secondary-bg-color:                transparent;
   --btn-text-secondary-hover-bg-color:          var(--theme2-100);
@@ -379,6 +385,14 @@
   --btn-hover-bg-color: var(--btn-text-hover-bg-color);
   --btn-border-color: var(--btn-text-border-color);
   --btn-hover-border-color: var(--btn-text-hover-border-color);
+
+  &.a-button--neutral {
+    --btn-color: var(--btn-text-neutral-color);
+    --btn-bg-color: var(--btn-text-neutral-bg-color);
+    --btn-hover-bg-color: var(--btn-text-neutral-hover-bg-color);
+    --btn-border-color: var(--btn-text-neutral-border-color);
+    --btn-hover-border-color: var(--btn-text-neutral-hover-border-color);
+  }
 
   &.a-button--secondary {
     --btn-color: var(--btn-text-secondary-color);

--- a/src/styles/aui/_aui.table.scss
+++ b/src/styles/aui/_aui.table.scss
@@ -43,10 +43,6 @@
     &.active {
       background-color: $gray-100;
     }
-
-    .a-button-transparent.has-icon:disabled {
-      box-shadow: none;
-    }
   }
 }
 

--- a/src/styles/organisms/_organisms.header.scss
+++ b/src/styles/organisms/_organisms.header.scss
@@ -46,8 +46,6 @@
  */
 
 .o-header__button {
-  @include a-button($header-btn-color, $header-btn-bg);
-
   border-left: var(--border-width) solid $header-border;
 }
 

--- a/src/templates/atoms.njk
+++ b/src/templates/atoms.njk
@@ -311,26 +311,26 @@
         <h4 class="u-margin-top-xl">Text buttons</h4>
         <div class="d">
             <div>
-                <button class="a-button-negative">Primary button</button>
+                <button class="a-button a-button--text">Primary button</button>
             </div>
             <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative"&gt;Primary button&lt;/button&gt;</code></pre>
-            </div>
-        </div>
-        <div class="d">
-            <div>
-                <button class="a-button-negative" disabled>Disabled button</button>
-            </div>
-            <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative" disabled&gt;Secondary button&lt;/button&gt;</code></pre>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--text"&gt;Primary button&lt;/button&gt;</code></pre>
             </div>
         </div>
         <div class="d">
             <div>
-                <button class="a-button-negative a-button--secondary">Secondary button</button>
+                <button class="a-button a-button--text" disabled>Disabled button</button>
             </div>
             <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative a-button--secondary"&gt;Secondary button&lt;/button&gt;</code></pre>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--text" disabled&gt;Secondary button&lt;/button&gt;</code></pre>
+            </div>
+        </div>
+        <div class="d">
+            <div>
+                <button class="a-button a-button--text a-button--secondary">Secondary button</button>
+            </div>
+            <div>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--text a-button--secondary"&gt;Secondary button&lt;/button&gt;</code></pre>
             </div>
         </div>
 
@@ -389,15 +389,15 @@
                     </button>
                 </div>
                 <div class="u-margin-bottom-xs">
-                    <button class="a-button-negative d-button a-button--l has-icon-left">
+                    <button class="a-button a-button--text d-button a-button--l has-icon-left">
                         {{ icon.render('arrow-left-1') }}
                         Icon left
                     </button>
-                    <button class="a-button-negative d-button has-icon-left">
+                    <button class="a-button a-button--text d-button has-icon-left">
                         {{ icon.render('arrow-left-1') }}
                         Icon left
                     </button>
-                    <button class="a-button-negative d-button a-button--s has-icon-left">
+                    <button class="a-button a-button--text d-button a-button--s has-icon-left">
                         {{ icon.render('arrow-left-1') }}
                         Icon left
                     </button>
@@ -422,7 +422,7 @@
   {{ icon.code('arrow-left-1') }}
   Icon left
 &lt;/button&gt;</code></pre>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative has-icon-left"&gt;
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--text has-icon-left"&gt;
   {{ icon.code('arrow-left-1') }}
   Icon left
 &lt;/button&gt;</code></pre>
@@ -445,15 +445,15 @@
                     </button>
                 </div>
                 <div class="u-margin-bottom-xs">
-                    <button class="a-button-negative d-button a-button--l has-icon-right">
+                    <button class="a-button a-button--text d-button a-button--l has-icon-right">
                         {{ icon.render('arrow-right-1') }}
                         Icon right
                     </button>
-                    <button class="a-button-negative d-button has-icon-right">
+                    <button class="a-button a-button--text d-button has-icon-right">
                         {{ icon.render('arrow-right-1') }}
                         Icon right
                     </button>
-                    <button class="a-button-negative d-button a-button--s has-icon-right">
+                    <button class="a-button a-button--text d-button a-button--s has-icon-right">
                         {{ icon.render('arrow-right-1') }}
                         Icon right
                     </button>
@@ -478,7 +478,7 @@
   {{ icon.code('arrow-right-1') }}
   Icon right
 &lt;/button&gt;</code></pre>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative has-icon-right"&gt;
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--text has-icon-right"&gt;
   {{ icon.code('arrow-right-1') }}
   Icon right
 &lt;/button&gt;</code></pre>
@@ -501,13 +501,13 @@
                     </button>
                 </div>
                 <div class="u-margin-bottom-xs">
-                    <button class="a-button-negative d-button a-button--l has-icon" aria-label="Download">
+                    <button class="a-button a-button--text d-button a-button--l has-icon" aria-label="Download">
                         {{ icon.render('download-bottom') }}
                     </button>
-                    <button class="a-button-negative d-button has-icon" aria-label="Download">
+                    <button class="a-button a-button--text d-button has-icon" aria-label="Download">
                         {{ icon.render('download-bottom') }}
                     </button>
-                    <button class="a-button-negative d-button a-button--s has-icon" aria-label="Download">
+                    <button class="a-button a-button--text d-button a-button--s has-icon" aria-label="Download">
                         {{ icon.render('download-bottom') }}
                     </button>
                 </div>
@@ -527,7 +527,7 @@
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button has-icon" aria-label="Download"&gt;
   {{ icon.code('download-bottom') }}
 &lt;/button&gt;</code></pre>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-negative has-icon" aria-label="Download"&gt;
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--text has-icon" aria-label="Download"&gt;
   {{ icon.code('download-bottom') }}
 &lt;/button&gt;</code></pre>
             </div>

--- a/src/templates/atoms.njk
+++ b/src/templates/atoms.njk
@@ -508,66 +508,6 @@
 &lt;/button&gt;</code></pre>
             </div>
         </div>
-        <div class="d">
-            <div>
-                <div>
-                    <button class="a-button a-button--neutral has-icon" aria-label="Download">
-                        {{ icon.render('download-bottom') }}
-                    </button>
-                </div>
-                <div>
-                    <button class="a-button-transparent a-button--default has-icon" aria-label="Close">
-                        {{ icon.render('remove') }}
-                    </button>
-                </div>
-            </div>
-            <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--neutral has-icon" aria-label="Download"&gt;
-  {{ icon.code('download-bottom') }}
-&lt;/button&gt;</code></pre>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-transparent a-button--default has-icon" aria-label="Close"&gt;
-  {{ icon.code('remove') }}
-&lt;/button&gt;</code></pre>
-            </div>
-        </div>
-        <div class="d">
-            <div>
-                <div>
-                    <button class="a-button-transparent has-icon" aria-label="Close">
-                        {{ icon.render('remove') }}
-                    </button>
-                </div>
-                <div>
-                    <button class="a-button-transparent a-button--success has-icon" aria-label="Close">
-                        {{ icon.render('remove') }}
-                    </button>
-                </div>
-                <div>
-                    <button class="a-button-transparent a-button--warning has-icon" aria-label="Close">
-                        {{ icon.render('remove') }}
-                    </button>
-                </div>
-                <div>
-                    <button class="a-button-transparent a-button--danger has-icon" aria-label="Close">
-                        {{ icon.render('remove') }}
-                    </button>
-                </div>
-            </div>
-            <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-transparent has-icon aria-label="Close""&gt;
-  {{ icon.code('remove') }}
-&lt;/button&gt;</code></pre>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-transparent a-button--success has-icon aria-label="Close""&gt;
-  {{ icon.code('remove') }}
-&lt;/button&gt;</code></pre>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-transparent a-button--warning has-icon aria-label="Close""&gt;
-  {{ icon.code('remove') }}
-&lt;/button&gt;</code></pre>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button-transparent a-button--danger has-icon aria-label="Close""&gt;
-  {{ icon.code('remove') }}
-&lt;/button&gt;</code></pre>
-            </div>
-        </div>
 
         <h4 class="u-margin-top-xl">Buttons with avatar</h4>
         <div class="d">

--- a/src/templates/atoms.njk
+++ b/src/templates/atoms.njk
@@ -620,6 +620,52 @@
         <h4 class="u-margin-top-xl">Buttons with avatar</h4>
         <div class="d">
             <div>
+                <button class="a-button a-button--text a-button--neutral a-button--l has-avatar">
+                    <span class="a-avatar a-avatar--l">
+                        <span class="a-avatar__icon" aria-label="avatarTitle">
+                            {{ icon.render('single-neutral') }}
+                        </span>
+                    </span>
+
+                    Sign in
+                </button>
+
+                <button class="a-button a-button--text a-button--neutral has-avatar">
+                    <span class="a-avatar">
+                        <span class="a-avatar__icon" aria-label="avatarTitle">
+                            {{ icon.render('single-neutral') }}
+                        </span>
+                    </span>
+
+                    Sign in
+                </button>
+
+                <button class="a-button a-button--text a-button--neutral a-button--s has-avatar">
+                    <span class="a-avatar a-avatar--s">
+                        <span class="a-avatar__icon" aria-label="avatarTitle">
+                            {{ icon.render('single-neutral') }}
+                        </span>
+                    </span>
+
+                    Sign in
+                </button>
+            </div>
+
+            <div>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--text a-button--neutral has-avatar"&gt;
+  &lt;span class="a-avatar"&gt;
+    &lt;span class="a-avatar__icon" aria-label="avatarTitle"&gt;
+      {{ icon.code('single-neutral') }}
+    &lt;/span&gt;
+  &lt;/span&gt;
+
+  Sign in
+&lt;/button&gt;</code></pre>
+            </div>
+        </div>
+
+        <div class="d">
+            <div>
                 <button class="a-button a-button--l has-avatar">
                     <span class="a-avatar a-avatar--primary a-avatar--l">
                         <span class="a-avatar__letter" aria-label="avatarTitle">A</span>

--- a/src/templates/atoms.njk
+++ b/src/templates/atoms.njk
@@ -282,15 +282,7 @@
                 <button class="a-button a-button--text" disabled>Disabled button</button>
             </div>
             <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--text" disabled&gt;Secondary button&lt;/button&gt;</code></pre>
-            </div>
-        </div>
-        <div class="d">
-            <div>
-                <button class="a-button a-button--text a-button--secondary">Secondary button</button>
-            </div>
-            <div>
-                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--text a-button--secondary"&gt;Secondary button&lt;/button&gt;</code></pre>
+                <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button a-button--text" disabled&gt;Disabled button&lt;/button&gt;</code></pre>
             </div>
         </div>
 

--- a/src/templates/molecules.njk
+++ b/src/templates/molecules.njk
@@ -210,9 +210,9 @@
                 </div>
                 <div>
                     <div class="m-button-group u-margin-bottom">
-                        <button class="a-button-negative">Primary</button>
-                        <button class="a-button-negative">Button</button>
-                        <button class="a-button-negative">Group</button>
+                        <button class="a-button a-button--text">Primary</button>
+                        <button class="a-button a-button--text">Button</button>
+                        <button class="a-button a-button--text">Group</button>
                     </div>
                 </div>
                 <div>
@@ -233,9 +233,9 @@
   &lt;button class="a-button"&gt;Group&lt;/button&gt;
 &lt;/div&gt;</code></pre>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div class="m-button-group"&gt;
-  &lt;button class="a-button-negative"&gt;Primary&lt;/button&gt;
-  &lt;button class="a-button-negative"&gt;Button&lt;/button&gt;
-  &lt;button class="a-button-negative"&gt;Group&lt;/button&gt;
+  &lt;button class="a-button a-button--text"&gt;Primary&lt;/button&gt;
+  &lt;button class="a-button a-button--text"&gt;Button&lt;/button&gt;
+  &lt;button class="a-button a-button--text"&gt;Group&lt;/button&gt;
 &lt;/div&gt;</code></pre>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div class="m-button-group"&gt;
   &lt;button class="a-button a-button--outlined"&gt;Primary&lt;/button&gt;
@@ -255,9 +255,9 @@
                 </div>
                 <div>
                     <div class="m-button-group m-button-group--vertical u-margin-bottom">
-                        <button class="a-button-negative">Primary</button>
-                        <button class="a-button-negative">Button</button>
-                        <button class="a-button-negative">Group</button>
+                        <button class="a-button a-button--text">Primary</button>
+                        <button class="a-button a-button--text">Button</button>
+                        <button class="a-button a-button--text">Group</button>
                     </div>
                 </div>
                 <div>
@@ -275,9 +275,9 @@
   &lt;button class="a-button"&gt;Group&lt;/button&gt;
 &lt;/div&gt;</code></pre>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div class="m-button-group m-button-group--vertical"&gt;
-  &lt;button class="a-button-negative"&gt;Primary&lt;/button&gt;
-  &lt;button class="a-button-negative"&gt;Button&lt;/button&gt;
-  &lt;button class="a-button-negative"&gt;Group&lt;/button&gt;
+  &lt;button class="a-button a-button--text"&gt;Primary&lt;/button&gt;
+  &lt;button class="a-button a-button--text"&gt;Button&lt;/button&gt;
+  &lt;button class="a-button a-button--text"&gt;Group&lt;/button&gt;
 &lt;/div&gt;</code></pre>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div class="m-button-group m-button-group--vertical"&gt;
   &lt;button class="a-button a-button--outlined"&gt;Primary&lt;/button&gt;

--- a/src/templates/molecules.njk
+++ b/src/templates/molecules.njk
@@ -80,7 +80,7 @@
         <div class="d">
             <div>
                 <div role="alertdialog" aria-labelledby="alert" class="m-alert">
-                    <button class="a-button-transparent has-icon m-alert__close" aria-label="Close">{{ icon.render('remove') }}</button>
+                    <button class="a-button a-button--text has-icon m-alert__close" aria-label="Close">{{ icon.render('remove') }}</button>
                     <h4 id="alert" class="h5 u-margin-bottom-xs">Alert</h4>
                     <p class="u-margin-bottom">Some explanation.</p>
                     <div class="m-alert__actions">
@@ -91,7 +91,7 @@
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div role="alertdialog" aria-labelledby="alert" class="m-alert"&gt;
-  &lt;button class="a-button-transparent has-icon m-alert__close" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
+  &lt;button class="a-button a-button--text has-icon m-alert__close" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
   &lt;h4 id="alert" class="h5 u-margin-bottom-xs"&gt;Alert&lt;/h4&gt;
   &lt;p class="u-margin-bottom"&gt;Some explanation.&lt;/p&gt;
   &lt;div class="m-alert__actions"&gt;
@@ -104,7 +104,7 @@
         <div class="d">
             <div>
                 <div role="alertdialog" aria-labelledby="alert-success" class="m-alert m-alert--success">
-                    <button class="a-button-transparent a-button--success has-icon m-alert__close" aria-label="Close">{{ icon.render('remove') }}</button>
+                    <button class="a-button a-button--text a-button--success has-icon m-alert__close" aria-label="Close">{{ icon.render('remove') }}</button>
                     <h4 id="alert-success" class="h5 u-margin-bottom-xs">Success alert</h4>
                     <p class="u-margin-bottom">Some explanation.</p>
                     <div class="m-alert__actions">
@@ -115,7 +115,7 @@
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div role="alertdialog" aria-labelledby="alert-success" class="m-alert m-alert--success"&gt;
-  &lt;button class="a-button-transparent a-button--success has-icon m-alert__close" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
+  &lt;button class="a-button a-button--text a-button--success has-icon m-alert__close" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
   &lt;h4 id="alert-success" class="h5 u-margin-bottom-xs"&gt;Success alert&lt;/h4&gt;
   &lt;p class="u-margin-bottom"&gt;Some explanation.&lt;/p&gt;
   &lt;div class="m-alert__actions"&gt;
@@ -128,7 +128,7 @@
         <div class="d">
             <div>
                 <div role="alertdialog" aria-labelledby="alert-warning" class="m-alert m-alert--warning">
-                    <button class="a-button-transparent a-button--warning has-icon m-alert__close" aria-label="Close">{{ icon.render('remove') }}</button>
+                    <button class="a-button a-button--text a-button--warning has-icon m-alert__close" aria-label="Close">{{ icon.render('remove') }}</button>
                     <h4 id="alert-warning" class="h5 u-margin-bottom-xs">Warning alert</h4>
                     <p class="u-margin-bottom">Some explanation.</p>
                     <div class="m-alert__actions">
@@ -139,7 +139,7 @@
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div role="alertdialog" aria-labelledby="alert-warning" class="m-alert m-alert--warning"&gt;
-  &lt;button class="a-button-transparent a-button--warning has-icon m-alert__close" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
+  &lt;button class="a-button a-button--text a-button--warning has-icon m-alert__close" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
   &lt;h4 id="alert-warning" class="h5 u-margin-bottom-xs"&gt;Warning alert&lt;/h4&gt;
   &lt;p class="u-margin-bottom"&gt;Some explanation.&lt;/p&gt;
   &lt;div class="m-alert__actions"&gt;
@@ -152,7 +152,7 @@
         <div class="d">
             <div>
                 <div role="alertdialog" aria-labelledby="alert-danger" class="m-alert m-alert--danger">
-                    <button class="a-button-transparent a-button--danger has-icon m-alert__close" aria-label="Close">{{ icon.render('remove') }}</button>
+                    <button class="a-button a-button--text a-button--danger has-icon m-alert__close" aria-label="Close">{{ icon.render('remove') }}</button>
                     <h4 id="alert-danger" class="h5 u-margin-bottom-xs">Danger alert</h4>
                     <p class="u-margin-bottom">Some explanation.</p>
                     <div class="m-alert__actions">
@@ -163,7 +163,7 @@
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div role="alertdialog" aria-labelledby="alert-danger" class="m-alert m-alert--danger"&gt;
-  &lt;button class="a-button-transparent a-button--danger has-icon m-alert__close" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
+  &lt;button class="a-button a-button--text a-button--danger has-icon m-alert__close" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
   &lt;h4 id="alert-danger" class="h5 u-margin-bottom-xs"&gt;Danger alert&lt;/h4&gt;
   &lt;p class="u-margin-bottom"&gt;Some explanation.&lt;/p&gt;
   &lt;div class="m-alert__actions"&gt;
@@ -1456,7 +1456,7 @@
                 <div class="m-modal" role="dialog" aria-modal="true" aria-labelledby="myModalTitle" aria-describedby="myModelDesc">
                     <div class="m-modal__content">
                         <div class="m-modal__header u-margin-bottom-xs">
-                            <button class="m-modal__close a-button-transparent a-button--default has-icon" aria-label="Close">{{ icon.render('remove') }}</button>
+                            <button class="m-modal__close a-button a-button--text a-button--neutral has-icon" aria-label="Close">{{ icon.render('remove') }}</button>
                             <h4 id="myModalTitle" class="h6">Aeneis</h4>
                         </div>
                         <div class="u-margin-bottom">
@@ -1473,7 +1473,7 @@
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div class="m-modal" role="dialog" aria-modal="true" aria-labelledby="myModalTitle" aria-describedby="myModelDesc"&gt;
   &lt;div class="m-modal__content"&gt;
     &lt;div class="m-modal__header u-margin-bottom-xs"&gt;
-      &lt;button class="m-modal__close a-button-transparent a-button--default has-icon" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
+      &lt;button class="m-modal__close a-button a-button--text a-button--neutral has-icon" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
       &lt;h4 id="myModalTitle" class="h6"&gt;Aeneis&lt;/h4&gt;
     &lt;/div&gt;
     &lt;div class="u-margin-bottom"&gt;
@@ -1492,7 +1492,7 @@
                 <div class="m-modal m-modal--l" role="dialog" aria-modal="true" aria-labelledby="myLargeModalTitle" aria-describedby="myLargeModelDesc">
                     <div class="m-modal__content">
                         <div class="m-modal__header u-margin-bottom-xs">
-                            <button class="m-modal__close a-button-transparent a-button--default has-icon" aria-label="Close">{{ icon.render('remove') }}</button>
+                            <button class="m-modal__close a-button a-button--text a-button--neutral has-icon" aria-label="Close">{{ icon.render('remove') }}</button>
                             <h4 class="h6">Aeneis</h4>
                         </div>
                         <div class="u-margin-bottom">
@@ -1509,7 +1509,7 @@
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div class="m-modal m-modal--l" role="dialog" aria-modal="true" aria-labelledby="myLargeModalTitle" aria-describedby="myLargeModelDesc"&gt;
   &lt;div class="m-modal__content"&gt;
     &lt;div class="m-modal__header u-margin-bottom-xs"&gt;
-      &lt;button class="m-modal__close a-button-transparent a-button--default has-icon" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
+      &lt;button class="m-modal__close a-button a-button--text a-button--neutral has-icon" aria-label="Close"&gt;{{ icon.code('remove') }}&lt;/button&gt;
       &lt;h4 id="myLargeModalTitle" class="h6"&gt;Aeneis&lt;/h4&gt;
     &lt;/div&gt;
     &lt;div class="u-margin-bottom"&gt;
@@ -2161,13 +2161,13 @@
             <div>
                 <div class="m-tag">
                     <span class="m-tag__label">My tag with delete button</span>
-                    <button class="a-button-transparent a-button--s a-button--danger has-icon" aria-label="Delete">{{ icon.render('remove') }}</button>
+                    <button class="a-button a-button--text a-button--s a-button--danger has-icon" aria-label="Delete">{{ icon.render('remove') }}</button>
                 </div>
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;div class="m-tag"&gt;
   &lt;span class="m-tag__label"&gt;My tag with delete button&lt;/span&gt;
-  &lt;button class="a-button-transparent a-button--s a-button--danger has-icon" aria-label="Delete"&gt;{{ icon.code('remove') }}&lt;/button&gt;
+  &lt;button class="a-button a-button--text a-button--s a-button--danger has-icon" aria-label="Delete"&gt;{{ icon.code('remove') }}&lt;/button&gt;
 &lt;/div&gt;</code></pre>
             </div>
         </div>
@@ -2279,18 +2279,18 @@
                         <li>
                             {{ icon.render('common-file-empty') }}
                             <span class="m-upload__filename">my-doc.pdf</span>
-                            <button class="m-upload__delete a-button-transparent a-button--default a-button--s has-icon">{{ icon.render('remove') }}<span class="u-screen-reader-only">Close</span></span></button>
+                            <button class="m-upload__delete a-button a-button--text a-button--neutral a-button--s has-icon">{{ icon.render('remove') }}<span class="u-screen-reader-only">Close</span></span></button>
                         </li>
                         <li>
                             {{ icon.render('common-file-empty') }}
                             <span class="m-upload__filename">my-pic.jpg</span>
-                            <button class="m-upload__delete a-button-transparent a-button--default a-button--s has-icon">{{ icon.render('remove') }}<span class="u-screen-reader-only">Close</span></span></button>
+                            <button class="m-upload__delete a-button a-button--text a-button--neutral a-button--s has-icon">{{ icon.render('remove') }}<span class="u-screen-reader-only">Close</span></span></button>
                         </li>
                         <li class="is-error">
                             {{ icon.render('alert-triangle') }}
                             <span class="m-upload__filename">my-unallowed-file.xml</span>
                             <span class="m-upload__error">This file format is not allowed.</span>
-                            <button class="m-upload__delete a-button-transparent a-button--danger a-button--s has-icon">{{ icon.render('remove') }}<span class="u-screen-reader-only">Close</span></span></button>
+                            <button class="m-upload__delete a-button a-button--text a-button--danger a-button--s has-icon">{{ icon.render('remove') }}<span class="u-screen-reader-only">Close</span></span></button>
                         </li>
                     </ul>
                 </div>
@@ -2316,18 +2316,18 @@
     &lt;li&gt;
       {{ icon.code('common-file-empty') }}
       &lt;span class="m-upload__filename"&gt;my-doc.pdf&lt;/span&gt;
-      &lt;button class="m-upload__delete a-button-transparent a-button--default a-button--s has-icon"&gt;{{ icon.code('remove') }}&lt;span class="u-screen-reader-only"&gt;Close&lt;/span&gt;&lt;/span&gt;&lt;/button&gt;
+      &lt;button class="m-upload__delete a-button a-button--text a-button--neutral a-button--s has-icon"&gt;{{ icon.code('remove') }}&lt;span class="u-screen-reader-only"&gt;Close&lt;/span&gt;&lt;/span&gt;&lt;/button&gt;
     &lt;/li&gt;
     &lt;li&gt;
       {{ icon.code('common-file-empty') }}
       &lt;span class="m-upload__filename"&gt;my-pic.jpg&lt;/span&gt;
-      &lt;button class="m-upload__delete a-button-transparent a-button--default a-button--s has-icon"&gt;{{ icon.code('remove') }}&lt;span class="u-screen-reader-only"&gt;Close&lt;/span&gt;&lt;/span&gt;&lt;/button&gt;
+      &lt;button class="m-upload__delete a-button a-button--text a-button--neutral a-button--s has-icon"&gt;{{ icon.code('remove') }}&lt;span class="u-screen-reader-only"&gt;Close&lt;/span&gt;&lt;/span&gt;&lt;/button&gt;
     &lt;/li&gt;
     &lt;li class="is-error"&gt;
       {{ icon.code('alert-triangle') }}
       &lt;span class="m-upload__filename"&gt;my-unallowed-file.xml&lt;/span&gt;
       &lt;span class="m-upload__error"&gt;This file format is not allowed.&lt;/span&gt;
-      &lt;button class="m-upload__delete a-button-transparent a-button--danger a-button--s has-icon"&gt;{{ icon.code('remove') }}&lt;span class="u-screen-reader-only"&gt;Close&lt;/span&gt;&lt;/span&gt;&lt;/button&gt;
+      &lt;button class="m-upload__delete a-button a-button--text a-button--danger a-button--s has-icon"&gt;{{ icon.code('remove') }}&lt;span class="u-screen-reader-only"&gt;Close&lt;/span&gt;&lt;/span&gt;&lt;/button&gt;
     &lt;/li&gt;
   &lt;/ul&gt;
 &lt;/div&gt;</code></pre>

--- a/src/templates/organisms.njk
+++ b/src/templates/organisms.njk
@@ -108,7 +108,7 @@
         <div class="d">
             <div>
                 <header class="o-header u-margin-bottom-3xl" aria-label="Demo header">
-                    <a href="#main-content" class="a-button-negative o-header__button o-header__button-skip">Skip to main content</a>
+                    <a href="#main-content" class="a-button a-button--text o-header__button o-header__button-skip">Skip to main content</a>
                     <a href="javascript:void(0);" class="o-header__logo">
                         <img src="./images/a-logo.svg" alt="Homepage Antwerp.">
                     </a>
@@ -116,7 +116,7 @@
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;header class="o-header"&gt;
-  &lt;a href="#main-content" class="a-button-negative o-header__button o-header__button-skip"&gt;Skip to main content&lt;/a&gt;
+  &lt;a href="#main-content" class="a-button a-button--text o-header__button o-header__button-skip"&gt;Skip to main content&lt;/a&gt;
   &lt;a href="#" class="o-header__logo"&gt;
     &lt;img src="./images/a-logo.svg" alt="Homepage Antwerp."&gt;
   &lt;/a&gt;
@@ -128,13 +128,13 @@
                 <header class="o-header" aria-label="Demo header with navigation">
                     <div class="o-header__content-wrapper">
                         <div class="o-header__content">
-                            <a href="#main-content" class="a-button-negative o-header__button o-header__button-skip">Skip to main content</a>
+                            <a href="#main-content" class="a-button a-button--text o-header__button o-header__button-skip">Skip to main content</a>
                             <a href="javascript:void(0);" class="o-header__logo">
                                 <img src="./images/a-logo.svg" alt="Homepage Antwerp.">
                             </a>
                         </div>
                         <div class="o-header__menu-items">
-                            <button class="a-button-negative o-header__button">Menu button</button>
+                            <button class="a-button a-button--text o-header__button">Menu button</button>
                         </div>
                     </div>
                 </header>
@@ -143,13 +143,13 @@
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;header class="o-header"&gt;
   &lt;div class="o-header__content-wrapper"&gt;
     &lt;div class="o-header__content"&gt;
-      &lt;a href="#main-content" class="a-button-negative o-header__button o-header__button-skip"&gt;Skip to main content&lt;/a&gt;
+      &lt;a href="#main-content" class="a-button a-button--text o-header__button o-header__button-skip"&gt;Skip to main content&lt;/a&gt;
       &lt;a href="#" class="o-header__logo"&gt;
         &lt;img src="./images/a-logo.svg" alt="Homepage Antwerp."&gt;
       &lt;/a&gt;
     &lt;/div&gt;
     &lt;div class="o-header__menu-items"&gt;
-      &lt;button href="#" class="a-button-negative o-header__button"&gt;Menu button&lt;/button&gt;
+      &lt;button href="#" class="a-button a-button--text o-header__button"&gt;Menu button&lt;/button&gt;
     &lt;/div&gt;
   &lt;/div&gt;
 &lt;/header&gt;</code></pre>

--- a/src/templates/organisms.njk
+++ b/src/templates/organisms.njk
@@ -108,7 +108,7 @@
         <div class="d">
             <div>
                 <header class="o-header u-margin-bottom-3xl" aria-label="Demo header">
-                    <a href="#main-content" class="a-button a-button--text o-header__button o-header__button-skip">Skip to main content</a>
+                    <a href="#main-content" class="a-button a-button--text a-button--neutral o-header__button o-header__button-skip">Skip to main content</a>
                     <a href="javascript:void(0);" class="o-header__logo">
                         <img src="./images/a-logo.svg" alt="Homepage Antwerp.">
                     </a>
@@ -116,7 +116,7 @@
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;header class="o-header"&gt;
-  &lt;a href="#main-content" class="a-button a-button--text o-header__button o-header__button-skip"&gt;Skip to main content&lt;/a&gt;
+  &lt;a href="#main-content" class="a-button a-button--text a-button--neutral o-header__button o-header__button-skip"&gt;Skip to main content&lt;/a&gt;
   &lt;a href="#" class="o-header__logo"&gt;
     &lt;img src="./images/a-logo.svg" alt="Homepage Antwerp."&gt;
   &lt;/a&gt;
@@ -128,13 +128,13 @@
                 <header class="o-header" aria-label="Demo header with navigation">
                     <div class="o-header__content-wrapper">
                         <div class="o-header__content">
-                            <a href="#main-content" class="a-button a-button--text o-header__button o-header__button-skip">Skip to main content</a>
+                            <a href="#main-content" class="a-button a-button--text a-button--neutral o-header__button o-header__button-skip">Skip to main content</a>
                             <a href="javascript:void(0);" class="o-header__logo">
                                 <img src="./images/a-logo.svg" alt="Homepage Antwerp.">
                             </a>
                         </div>
                         <div class="o-header__menu-items">
-                            <button class="a-button a-button--text o-header__button">Menu button</button>
+                            <button class="a-button a-button--text a-button--neutral o-header__button">Menu button</button>
                         </div>
                     </div>
                 </header>
@@ -143,13 +143,13 @@
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;header class="o-header"&gt;
   &lt;div class="o-header__content-wrapper"&gt;
     &lt;div class="o-header__content"&gt;
-      &lt;a href="#main-content" class="a-button a-button--text o-header__button o-header__button-skip"&gt;Skip to main content&lt;/a&gt;
+      &lt;a href="#main-content" class="a-button a-button--text a-button--neutral o-header__button o-header__button-skip"&gt;Skip to main content&lt;/a&gt;
       &lt;a href="#" class="o-header__logo"&gt;
         &lt;img src="./images/a-logo.svg" alt="Homepage Antwerp."&gt;
       &lt;/a&gt;
     &lt;/div&gt;
     &lt;div class="o-header__menu-items"&gt;
-      &lt;button href="#" class="a-button a-button--text o-header__button"&gt;Menu button&lt;/button&gt;
+      &lt;button href="#" class="a-button a-button--text a-button--neutral o-header__button"&gt;Menu button&lt;/button&gt;
     &lt;/div&gt;
   &lt;/div&gt;
 &lt;/header&gt;</code></pre>

--- a/src/templates/organisms.njk
+++ b/src/templates/organisms.njk
@@ -668,17 +668,17 @@
                 <ul class="o-tag-list">
                     <li class="m-tag">
                         <span class="m-tag__label">Thomas Edison</span>
-                        <button class="a-button-transparent a-button--s a-button--danger has-icon"
+                        <button class="a-button a-button--text a-button--s a-button--danger has-icon"
                                 aria-label="Delete">{{ icon.render('remove') }}</button>
                     </li>
                     <li class="m-tag">
                         <span class="m-tag__label">Leonardo da Vinci</span>
-                        <button class="a-button-transparent a-button--s a-button--danger has-icon"
+                        <button class="a-button a-button--text a-button--s a-button--danger has-icon"
                                 aria-label="Delete">{{ icon.render('remove') }}</button>
                     </li>
                     <li class="m-tag">
                         <span class="m-tag__label">Albert Einstein</span>
-                        <button class="a-button-transparent a-button--s a-button--danger has-icon"
+                        <button class="a-button a-button--text a-button--s a-button--danger has-icon"
                                 aria-label="Delete">{{ icon.render('remove') }}</button>
                     </li>
                 </ul>
@@ -687,15 +687,15 @@
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;ul class="o-tag-list"&gt;
   &lt;li class="m-tag"&gt;
     &lt;span class="m-tag__label"&gt;Thomas Edison&lt;/span&gt;
-    &lt;button class="a-button-transparent a-button--s a-button--danger has-icon" aria-label="Delete"&gt;{{ icon.code('remove') }}&lt;/button&gt;
+    &lt;button class="a-button a-button--text a-button--s a-button--danger has-icon" aria-label="Delete"&gt;{{ icon.code('remove') }}&lt;/button&gt;
   &lt;/li&gt;
   &lt;li class="m-tag"&gt;
     &lt;span class="m-tag__label"&gt;Leonardo da Vinci&lt;/span&gt;
-    &lt;button class="a-button-transparent a-button--s a-button--danger has-icon" aria-label="Delete"&gt;{{ icon.code('remove') }}&lt;/button&gt;
+    &lt;button class="a-button a-button--text a-button--s a-button--danger has-icon" aria-label="Delete"&gt;{{ icon.code('remove') }}&lt;/button&gt;
   &lt;/li&gt;
   &lt;li class="m-tag"&gt;
     &lt;span class="m-tag__label"&gt;Albert Einstein&lt;/span&gt;
-    &lt;button class="a-button-transparent a-button--s a-button--danger has-icon" aria-label="Delete"&gt;{{ icon.code('remove') }}&lt;/button&gt;
+    &lt;button class="a-button a-button--text a-button--s a-button--danger has-icon" aria-label="Delete"&gt;{{ icon.code('remove') }}&lt;/button&gt;
   &lt;/li&gt;
 &lt;/ul&gt;</code></pre>
             </div>


### PR DESCRIPTION
Bijhorend ticket: https://jira.antwerpen.be/browse/UDH-9

Belangrijkste veranderingen:
- `.a-button-negative` is veranderd naar `.a-button.a-button--text`.
- Er is ook een grijze variant van de `.a-button--text` beschikbaar:  `.a-button.a-button--text.a-button--neutral`. Deze wordt gebruikt op twee plaatsen:
  - Als "Sign in"-button bij de buttons with avatar.
  - Als "Menu"-button bij de navigation menu.

<img width="1251" alt="Screenshot 2021-10-07 at 14 20 30" src="https://user-images.githubusercontent.com/4232875/136383009-4be9967c-c970-478a-bd25-823302e9c9eb.png">

<img width="1211" alt="Screenshot 2021-10-07 at 14 59 00" src="https://user-images.githubusercontent.com/4232875/136388950-44ad1478-c3ea-4463-af62-b2b7c5a37d1e.png">

<img width="1241" alt="Screenshot 2021-10-07 at 14 59 16" src="https://user-images.githubusercontent.com/4232875/136388974-ac685223-c1ba-490c-94a2-a6a76d02cb7e.png">


