### PR TITLE
Fix incorrect border of table cell with "position: sticky" on Firefox

### DIFF
--- a/src/styles/atoms/_atoms.table.scss
+++ b/src/styles/atoms/_atoms.table.scss
@@ -75,6 +75,9 @@
 
   th,
   td {
+    // https://stackoverflow.com/a/41883019
+    // Fix incorrect border of td/th with "position: sticky" on Firefox
+    background-clip: padding-box;
     padding: var(--spacer-xs);
 
     &:not(.u-text-center):not(.u-text-right):not(.u-text-justify) {


### PR DESCRIPTION
![Screenshot 2022-01-14 at 16 54 38](https://user-images.githubusercontent.com/4232875/149546918-ec09ee80-2cca-4fc3-b2fe-f2d0eb873f4b.png)
![Screenshot 2022-01-14 at 16 54 45](https://user-images.githubusercontent.com/4232875/149546927-951bdfe3-5715-488a-8fcc-c706b66b71cf.png)

