### PR TITLE
Decrease focus outline on Safari to make it connect to input field border

### DIFF
--- a/src/styles/atoms/_atoms.input.scss
+++ b/src/styles/atoms/_atoms.input.scss
@@ -265,7 +265,8 @@ textarea {
     }
 
     &:focus-within .a-input__wrapper {
-      @include focus;
+      outline: 5px auto Highlight;
+      outline: 2px auto -webkit-focus-ring-color; // Decrease focus outline on Safari to make it connect to input field border
     }
   }
 


### PR DESCRIPTION
**Before**
![Screenshot 2022-01-24 at 08 48 38](https://user-images.githubusercontent.com/4232875/150742353-30a2a141-6206-40f8-adc9-6e363ca4fa47.png)

**After**
![Screenshot 2022-01-24 at 08 44 37](https://user-images.githubusercontent.com/4232875/150742341-4c3d1b6a-5829-4be8-b8fd-4d1bf2c0695e.png)

