### PR TITLE
Update spinner in button

### DIFF
--- a/src/styles/atoms/_atoms.button.scss
+++ b/src/styles/atoms/_atoms.button.scss
@@ -240,7 +240,8 @@
     width: auto;
   }
 
-  .ai {
+  .ai,
+  .a-spinner {
     font-size: var(--btn-icon-size);
     line-height: 0;
   }
@@ -603,7 +604,8 @@
   &.has-icon-right {
     position: relative;
 
-    .ai {
+    .ai,
+    .a-spinner {
       position: absolute;
       top: 50%;
       transform: translateY(-50%);
@@ -614,7 +616,8 @@
   &.has-icon-left {
     padding-left: var(--spacer-xl);
 
-    .ai {
+    .ai,
+    .a-spinner {
       left: 0;
     }
   }
@@ -622,15 +625,18 @@
   &.has-icon-right {
     padding-right: var(--spacer-xl);
 
-    .ai {
+    .ai,
+    .a-spinner {
       right: 0;
     }
   }
 }
 
 .a-button--s {
-  &.has-icon-left .ai,
-  &.has-icon-right .ai {
+  &.has-icon-left .a,
+  &.has-icon-left .a-spinner,
+  &.has-icon-right .ai,
+  &.has-icon-right .a-spinner {
     width: var(--spacer-l);
   }
 
@@ -644,8 +650,10 @@
 }
 
 .a-button--l {
-  &.has-icon-left .ai,
-  &.has-icon-right .ai {
+  &.has-icon-left .a,
+  &.has-icon-left .a-spinner,
+  &.has-icon-right .ai,
+  &.has-icon-right .a-spinner {
     width: var(--spacer-xxl);
   }
 
@@ -670,7 +678,8 @@
   vertical-align: middle;
   width: var(--spacer-xl);
 
-  .ai {
+  .ai,
+  .a-spinner {
     left: 0;
     position: absolute;
     top: 50%;
@@ -682,7 +691,8 @@
 .a-button--s.has-icon {
   width: var(--spacer-l);
 
-  .ai {
+  .ai,
+  .a-spinner {
     width: var(--spacer-l);
   }
 }
@@ -690,7 +700,8 @@
 .a-button--l.has-icon {
   width: var(--spacer-xxl);
 
-  .ai {
+  .ai,
+  .a-spinner {
     width: var(--spacer-xxl);
   }
 }
@@ -752,4 +763,14 @@
   &.has-avatar-with-inset {
     padding-left: calc(var(--shared-avatar-size-l) + var(--spacer));
   }
+}
+
+/**
+ * BUTTON WITH SPINNER
+ * -------------------------------------------------------------------
+ */
+
+.a-button .a-spinner {
+  --spinner-color: var(--btn-color);
+  --spinner-text-color: var(--btn-color);
 }

--- a/src/styles/atoms/_atoms.spinner.scss
+++ b/src/styles/atoms/_atoms.spinner.scss
@@ -32,6 +32,7 @@
 .a-spinner {
   align-items: center;
   display: inline-flex;
+  justify-content: center;
 }
 
 .a-spinner__circle {
@@ -70,6 +71,11 @@
  */
 
 .a-spinner {
+  &.a-spinner--xs {
+    --spinner-size: var(--spacer-s);
+    --spinner-thickness: .0625rem;
+  }
+
   &.a-spinner--s {
     --spinner-size: var(--spacer);
     --spinner-thickness: .125rem;
@@ -77,7 +83,7 @@
 
   &.a-spinner--l {
     --spinner-size: 4rem;
-    --spinner-thickness: 4px;
+    --spinner-thickness: var(--spacer-3xs);
   }
 
   &.a-spinner--vertical {

--- a/src/templates/atoms.njk
+++ b/src/templates/atoms.njk
@@ -518,22 +518,44 @@
             <div>
                 <div>
                     <button class="a-button d-button a-button--l has-icon-right">
-                        {{ icon.render('synchronize-arrows-1', true, 'ai ai--spin') }}
+                        <span class="a-spinner a-spinner--s" role="alert">
+                            <span class="a-spinner__circle">
+                                <span class="u-screen-reader-only">Fetching data...</span>
+                            </span>
+                        </span>
+
                         Loading
                     </button>
+
                     <button class="a-button d-button has-icon-right">
-                        {{ icon.render('synchronize-arrows-1', true, 'ai ai--spin') }}
+                        <span class="a-spinner a-spinner--s" role="alert">
+                            <span class="a-spinner__circle">
+                                <span class="u-screen-reader-only">Fetching data...</span>
+                            </span>
+                        </span>
+
                         Loading
                     </button>
+
                     <button class="a-button d-button a-button--s has-icon-right">
-                        {{ icon.render('synchronize-arrows-1', true, 'ai ai--spin') }}
+                        <span class="a-spinner a-spinner--xs" role="alert">
+                            <span class="a-spinner__circle">
+                                <span class="u-screen-reader-only">Fetching data...</span>
+                            </span>
+                        </span>
+
                         Loading
                     </button>
                 </div>
             </div>
             <div>
                 <pre class="a-pre a-pre--scrollable"><code class="html">&lt;button class="a-button has-icon-right"&gt;
-  {{ icon.code('synchronize-arrows-1', true, 'ai ai--spin') }}
+  &lt;span class="a-spinner a-spinner--xs" role="alert"&gt;
+    &lt;span class="a-spinner__circle"&gt;
+      &lt;span class="u-screen-reader-only"&gt;Fetching data...&lt;/span&gt;
+    &lt;/span&gt;
+  &lt;/span&gt;
+
   Loading
 &lt;/button&gt;</code></pre>
             </div>


### PR DESCRIPTION
De Font Awesome loading indicator is vervangen door de `.a-spinner`.

![Screenshot 2022-01-24 at 15 44 06](https://user-images.githubusercontent.com/4232875/150809933-caada498-4e78-4c8b-8fdc-fe77f6893906.png)

Ik heb een extra small variant van de `.a-spinner` toegevoegd. Ik heb deze niet gedocumenteerd bij de spinner, want momenteel is die extra small variant enkel bedoeld in een kleine button.

Ik heb de spinner ook even getest in alle mogelijke buttons:

![Screenshot 2022-01-24 at 15 58 43](https://user-images.githubusercontent.com/4232875/150810698-18016e4f-ec39-4c54-acc2-cd62fb8e82a9.png)

![Screenshot 2022-01-24 at 15 58 54](https://user-images.githubusercontent.com/4232875/150810714-c0b1ce2f-2f87-4faf-aef7-a0476ea38349.png)

![Screenshot 2022-01-24 at 15 59 25](https://user-images.githubusercontent.com/4232875/150810730-1d12fbcc-d94b-4080-9907-b9e5478bb198.png)

